### PR TITLE
do not inherit dependencies in examples, fixes #36

### DIFF
--- a/example/example-java/pom.xml
+++ b/example/example-java/pom.xml
@@ -11,12 +11,10 @@
 
   <artifactId>camunda-bpm-data-example-java</artifactId>
   <name>${project.artifactId}</name>
-  <packaging>jar</packaging>
 
   <properties>
     <jacoco.skip>false</jacoco.skip>
   </properties>
-
 
   <dependencies>
     <dependency>
@@ -26,7 +24,6 @@
     <dependency>
       <groupId>io.toolisticon.springboot</groupId>
       <artifactId>springboot-swagger-starter</artifactId>
-      <version>0.0.4</version>
     </dependency>
 
     <dependency>
@@ -44,6 +41,87 @@
       <groupId>org.camunda.bpm.extension.mockito</groupId>
       <artifactId>camunda-bpm-mockito</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.springboot</groupId>
+      <artifactId>camunda-bpm-spring-boot-starter-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine-plugin-spin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
+    </dependency>
+
+    <!-- Jackson -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-kotlin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-junit</artifactId>
+      <version>${jgiven.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-spring</artifactId>
+      <version>${jgiven.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-html5-report</artifactId>
+      <version>${jgiven.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.holunda.testing</groupId>
+      <artifactId>camunda-bpm-jgiven</artifactId>
     </dependency>
   </dependencies>
 

--- a/example/example-java/pom.xml
+++ b/example/example-java/pom.xml
@@ -25,24 +25,6 @@
       <groupId>io.toolisticon.springboot</groupId>
       <artifactId>springboot-swagger-starter</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.holunda.data</groupId>
-      <artifactId>camunda-bpm-data-mockito</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.camunda.bpm.springboot</groupId>
-      <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
-      <version>${camunda-spring-boot.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.camunda.bpm.extension.mockito</groupId>
-      <artifactId>camunda-bpm-mockito</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
@@ -97,21 +79,19 @@
 
     <!-- Testing -->
     <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-junit</artifactId>
-      <version>${jgiven.version}</version>
+      <groupId>io.holunda.data</groupId>
+      <artifactId>camunda-bpm-data-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm.springboot</groupId>
+      <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-spring</artifactId>
-      <version>${jgiven.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-html5-report</artifactId>
-      <version>${jgiven.version}</version>
+      <groupId>org.camunda.bpm.extension.mockito</groupId>
+      <artifactId>camunda-bpm-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -122,7 +102,25 @@
     <dependency>
       <groupId>io.holunda.testing</groupId>
       <artifactId>camunda-bpm-jgiven</artifactId>
+      <scope>test</scope>
     </dependency>
+    <!--
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-html5-report</artifactId>
+      <scope>test</scope>
+    </dependency>
+    -->
   </dependencies>
 
 </project>

--- a/example/example-kotlin/pom.xml
+++ b/example/example-kotlin/pom.xml
@@ -70,35 +70,6 @@
       <artifactId>h2</artifactId>
     </dependency>
 
-    <!-- Testing -->
-    <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-junit</artifactId>
-      <version>${jgiven.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-spring</artifactId>
-      <version>${jgiven.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-html5-report</artifactId>
-      <version>${jgiven.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.holunda.testing</groupId>
-      <artifactId>camunda-bpm-jgiven</artifactId>
-    </dependency>
-
     <!-- Kotlin -->
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
@@ -136,6 +107,40 @@
       <groupId>io.toolisticon.springboot</groupId>
       <artifactId>springboot-swagger-starter</artifactId>
     </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.holunda.data</groupId>
+      <artifactId>camunda-bpm-data-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.holunda.testing</groupId>
+      <artifactId>camunda-bpm-jgiven</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-html5-report</artifactId>
+      <scope>test</scope>
+    </dependency>
+    -->
   </dependencies>
 
   <build>

--- a/example/example-kotlin/pom.xml
+++ b/example/example-kotlin/pom.xml
@@ -11,7 +11,6 @@
 
   <artifactId>camunda-bpm-data-example-kotlin</artifactId>
   <name>${project.artifactId}</name>
-  <packaging>jar</packaging>
 
   <properties>
     <jacoco.skip>false</jacoco.skip>
@@ -20,11 +19,84 @@
   <dependencies>
     <dependency>
       <groupId>io.holunda.data</groupId>
-      <artifactId>camunda-bpm-data</artifactId>
+      <artifactId>camunda-bpm-data-kotlin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.holunda.data</groupId>
-      <artifactId>camunda-bpm-data-kotlin</artifactId>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.springboot</groupId>
+      <artifactId>camunda-bpm-spring-boot-starter-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine-plugin-spin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
+    </dependency>
+
+    <!-- Jackson -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-kotlin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-junit</artifactId>
+      <version>${jgiven.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-spring</artifactId>
+      <version>${jgiven.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.tngtech.jgiven</groupId>
+      <artifactId>jgiven-html5-report</artifactId>
+      <version>${jgiven.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.holunda.testing</groupId>
+      <artifactId>camunda-bpm-jgiven</artifactId>
     </dependency>
 
     <!-- Kotlin -->
@@ -63,9 +135,9 @@
     <dependency>
       <groupId>io.toolisticon.springboot</groupId>
       <artifactId>springboot-swagger-starter</artifactId>
-      <version>0.0.4</version>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/example/example-kotlin/src/test/kotlin/itest/CamundaBpmDataITestBase.kt
+++ b/example/example-kotlin/src/test/kotlin/itest/CamundaBpmDataITestBase.kt
@@ -63,7 +63,7 @@ import java.util.*
 /**
  * Alias for the when
  */
-fun <G, W, T> ScenarioTestBase<G, W, T>.whenever() = `when`()
+fun <G, W, T> ScenarioTestBase<G, W, T>.whenever(): W = `when`()
 
 /**
  * Base for ITests.
@@ -145,7 +145,7 @@ abstract class CamundaBpmDataITestBase : SpringScenarioTest<ActionStage, ActionS
     )
 
     fun createVariableMapUntyped(): VariableMap {
-      val variables = createVariables();
+      val variables = createVariables()
       allValues.values.forEach {
         variables.putValue(it.variable.name, it.value)
       }

--- a/example/example-kotlin/src/test/kotlin/itest/VariableMapAdapterITest.kt
+++ b/example/example-kotlin/src/test/kotlin/itest/VariableMapAdapterITest.kt
@@ -15,7 +15,6 @@ import io.holunda.camunda.bpm.data.itest.CamundaBpmDataITestBase.Companion.Value
 import io.holunda.camunda.bpm.data.itest.CamundaBpmDataITestBase.Companion.Values.SET_STRING
 import io.holunda.camunda.bpm.data.itest.CamundaBpmDataITestBase.Companion.Values.SHORT
 import io.holunda.camunda.bpm.data.itest.CamundaBpmDataITestBase.Companion.Values.STRING
-import org.assertj.core.api.Assertions.assertThat
 import org.camunda.bpm.engine.variable.Variables.createVariables
 import org.junit.Rule
 import org.junit.Test
@@ -25,8 +24,9 @@ import java.util.*
 
 class VariableMapAdapterITest : CamundaBpmDataITestBase() {
 
+  @Suppress("RedundantVisibilityModifier")
   @get: Rule
-  public val thrown = ExpectedException.none()
+  public val thrown: ExpectedException = ExpectedException.none()
 
   @Autowired
   lateinit var delegateConfiguration: DelegateConfiguration
@@ -104,96 +104,96 @@ class VariableMapAdapterITest : CamundaBpmDataITestBase() {
   }
 
   @Test
-  fun `should throw correct NSO on basic setLocal exception`() {
+  fun `should throw correct UO exception on basic setLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     STRING_VAR.on(createVariableMapUntyped()).setLocal(STRING.value)
   }
 
   @Test
-  fun `should throw correct NSO on list setLocal exception`() {
+  fun `should throw correct UO exception on list setLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     LIST_STRING_VAR.on(createVariableMapUntyped()).setLocal(LIST_STRING.value)
   }
 
   @Test
-  fun `should throw correct NSO on set setLocal exception`() {
+  fun `should throw correct UO exception on set setLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     SET_STRING_VAR.on(createVariableMapUntyped()).setLocal(SET_STRING.value)
   }
 
   @Test
-  fun `should throw correct NSO on map setLocal exception`() {
+  fun `should throw correct UO exception on map setLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     MAP_STRING_DATE_VAR.on(createVariableMapUntyped()).setLocal(MAP_STRING_DATE.value)
   }
 
   @Test
-  fun `should throw correct NSO on basic removeLocal exception`() {
+  fun `should throw correct UO exception on basic removeLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     STRING_VAR.on(createVariableMapUntyped()).removeLocal()
   }
 
   @Test
-  fun `should throw correct NSO on list removeLocal exception`() {
+  fun `should throw correct UO exception on list removeLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     LIST_STRING_VAR.on(createVariableMapUntyped()).removeLocal()
   }
 
   @Test
-  fun `should throw correct NSO on set removeLocal exception`() {
+  fun `should throw correct UO exception on set removeLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     SET_STRING_VAR.on(createVariableMapUntyped()).removeLocal()
   }
 
   @Test
-  fun `should throw correct NSO on map removeLocal exception`() {
+  fun `should throw correct UO exception on map removeLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     MAP_STRING_DATE_VAR.on(createVariableMapUntyped()).removeLocal()
   }
   @Test
-  fun `should throw correct NSO on basic getLocal exception`() {
+  fun `should throw correct UO exception on basic getLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     STRING_VAR.from(createVariableMapUntyped()).local
   }
 
   @Test
-  fun `should throw correct NSO on list getLocal exception`() {
+  fun `should throw correct UO exception on list getLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     LIST_STRING_VAR.from(createVariableMapUntyped()).local
   }
 
   @Test
-  fun `should throw correct NSO on set getLocal exception`() {
+  fun `should throw correct UO exception on set getLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     SET_STRING_VAR.from(createVariableMapUntyped()).local
   }
 
   @Test
-  fun `should throw correct NSO on map getLocal exception`() {
+  fun `should throw correct UO exception on map getLocal`() {
     thrown.expect(UnsupportedOperationException::class.java)
     MAP_STRING_DATE_VAR.from(createVariableMapUntyped()).local
   }
 
   @Test
-  fun `should throw correct NSO on basic getLocalOptional exception`() {
+  fun `should throw correct UO exception on basic getLocalOptional`() {
     thrown.expect(UnsupportedOperationException::class.java)
     STRING_VAR.from(createVariableMapUntyped()).localOptional
   }
 
   @Test
-  fun `should throw correct NSO on list getLocalOptional exception`() {
+  fun `should throw correct UO exception on list getLocalOptional`() {
     thrown.expect(UnsupportedOperationException::class.java)
     LIST_STRING_VAR.from(createVariableMapUntyped()).localOptional
   }
 
   @Test
-  fun `should throw correct NSO on set getLocalOptional exception`() {
+  fun `should throw correct UO exception on set getLocalOptional`() {
     thrown.expect(UnsupportedOperationException::class.java)
     SET_STRING_VAR.from(createVariableMapUntyped()).localOptional
   }
 
   @Test
-  fun `should throw correct NSO on map getLocalOptional exception`() {
+  fun `should throw correct UO exception on map getLocalOptional`() {
     thrown.expect(UnsupportedOperationException::class.java)
     MAP_STRING_DATE_VAR.from(createVariableMapUntyped()).localOptional
   }
@@ -378,7 +378,5 @@ class VariableMapAdapterITest : CamundaBpmDataITestBase() {
     // wrong value type
     wrongMapValueType.from(variables).optional
   }
-
-
 }
 

--- a/example/example-kotlin/src/test/kotlin/itest/VariableScopeAdapterITest.kt
+++ b/example/example-kotlin/src/test/kotlin/itest/VariableScopeAdapterITest.kt
@@ -10,6 +10,7 @@ import java.util.*
 
 class VariableScopeAdapterITest : CamundaBpmDataITestBase() {
 
+  @Suppress("RedundantVisibilityModifier")
   @get: Rule
   public val thrown = ExpectedException.none()
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -29,6 +29,7 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- CAMUNDA BPM DATA -->
       <dependency>
         <groupId>io.holunda.data</groupId>
         <artifactId>camunda-bpm-data</artifactId>
@@ -45,96 +46,33 @@
         <scope>test</scope>
         <version>${project.version}</version>
       </dependency>
+
+      <!-- CAMUNDA SPRING BOOT -->
+      <dependency>
+        <groupId>org.camunda.bpm.springboot</groupId>
+        <artifactId>camunda-bpm-spring-boot-starter-rest</artifactId>
+        <version>${camunda-spring-boot.version}</version>
+      </dependency>
+
+      <!-- TOOLS -->
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-all</artifactId>
+        <version>${groovy.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.toolisticon.springboot</groupId>
+        <artifactId>springboot-swagger-starter</artifactId>
+        <version>0.0.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.holunda.testing</groupId>
+        <artifactId>camunda-bpm-jgiven</artifactId>
+        <version>0.0.5</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <dependencies>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.camunda.bpm.springboot</groupId>
-      <artifactId>camunda-bpm-spring-boot-starter-rest</artifactId>
-      <version>${camunda-spring-boot.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.camunda.bpm</groupId>
-      <artifactId>camunda-engine-plugin-spin</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.camunda.spin</groupId>
-      <artifactId>camunda-spin-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.camunda.spin</groupId>
-      <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-    </dependency>
-
-    <!-- Jackson -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-kotlin</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <version>${groovy.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-    </dependency>
-
-    <!-- Testing -->
-    <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-junit</artifactId>
-      <version>${jgiven.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-spring</artifactId>
-      <version>${jgiven.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-html5-report</artifactId>
-      <version>${jgiven.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.holunda.testing</groupId>
-      <artifactId>camunda-bpm-jgiven</artifactId>
-      <version>0.0.5</version>
-      <scope>test</scope>
-    </dependency>
-
-  </dependencies>
 
   <build>
     <plugins>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -71,7 +71,26 @@
         <version>0.0.5</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>com.tngtech.jgiven</groupId>
+        <artifactId>jgiven-junit</artifactId>
+        <version>${jgiven.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.tngtech.jgiven</groupId>
+        <artifactId>jgiven-spring</artifactId>
+        <version>${jgiven.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.tngtech.jgiven</groupId>
+        <artifactId>jgiven-html5-report</artifactId>
+        <version>${jgiven.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
+
   </dependencyManagement>
 
   <build>

--- a/mockito/pom.xml
+++ b/mockito/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <jacoco.skip>false</jacoco.skip>
+    <mockito-kotlin.version>1.6.0</mockito-kotlin.version>
   </properties>
 
   <dependencies>
@@ -33,7 +34,22 @@
     <dependency>
       <groupId>com.nhaarman</groupId>
       <artifactId>mockito-kotlin</artifactId>
-      <version>1.6.0</version>
+      <version>${mockito-kotlin.version}</version>
+      <exclusions>
+        <!-- Exclude old versions -->
+        <exclusion>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-reflect</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Kotlin -->
@@ -59,16 +75,8 @@
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-reflect</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.github.microutils</groupId>
-      <artifactId>kotlin-logging</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <artifactId>kotlin-stdlib</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+
+    <!-- Testing -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>

--- a/mockito/src/main/kotlin/CamundaBpmDataMockito.kt
+++ b/mockito/src/main/kotlin/CamundaBpmDataMockito.kt
@@ -4,7 +4,6 @@ import org.camunda.bpm.engine.RuntimeService
 import org.camunda.bpm.engine.TaskService
 import org.camunda.bpm.engine.variable.VariableMap
 
-
 /**
  * Collection of fluent mock builder factory methods.
  */
@@ -16,8 +15,7 @@ object CamundaBpmDataMockito {
      * @return fluent builder.
      */
     @JvmStatic
-    fun taskServiceVariableMockBuilder(taskService: TaskService)
-        = TaskServiceVariableMockBuilder(taskService = taskService)
+    fun taskServiceVariableMockBuilder(taskService: TaskService) = TaskServiceVariableMockBuilder(taskService = taskService)
 
     /**
      * Constructs a task service variable mock builder.
@@ -27,8 +25,7 @@ object CamundaBpmDataMockito {
      * @return fluent builder.
      */
     @JvmStatic
-    fun taskServiceVariableMockBuilder(taskService: TaskService, variables: VariableMap, localVariables: VariableMap)
-        = TaskServiceVariableMockBuilder(taskService = taskService, variables = variables, localVariables = localVariables)
+    fun taskServiceVariableMockBuilder(taskService: TaskService, variables: VariableMap, localVariables: VariableMap) = TaskServiceVariableMockBuilder(taskService = taskService, variables = variables, localVariables = localVariables)
 
 
     /**
@@ -37,8 +34,7 @@ object CamundaBpmDataMockito {
      * @return verifier to simplify assertions.
      */
     @JvmStatic
-    fun taskServiceMockVerifier(taskService: TaskService)
-        = TaskServiceMockVerifier(taskService)
+    fun taskServiceMockVerifier(taskService: TaskService) = TaskServiceMockVerifier(taskService)
 
     /**
      * Constructs a runtime service variable mock builder.
@@ -46,8 +42,7 @@ object CamundaBpmDataMockito {
      * @return fluent builder.
      */
     @JvmStatic
-    fun runtimeServiceVariableMockBuilder(runtimeService: RuntimeService)
-        = RuntimeServiceVariableMockBuilder(runtimeService = runtimeService)
+    fun runtimeServiceVariableMockBuilder(runtimeService: RuntimeService) = RuntimeServiceVariableMockBuilder(runtimeService = runtimeService)
 
     /**
      * Constructs a runtime service variable mock builder.
@@ -57,8 +52,7 @@ object CamundaBpmDataMockito {
      * @return fluent builder.
      */
     @JvmStatic
-    fun runtimeServiceVariableMockBuilder(runtimeService: RuntimeService, variables: VariableMap, localVariables: VariableMap)
-        = RuntimeServiceVariableMockBuilder(runtimeService = runtimeService, variables = variables, localVariables = localVariables)
+    fun runtimeServiceVariableMockBuilder(runtimeService: RuntimeService, variables: VariableMap, localVariables: VariableMap) = RuntimeServiceVariableMockBuilder(runtimeService = runtimeService, variables = variables, localVariables = localVariables)
 
     /**
      * Constructs a verifier for runtime service mock.
@@ -66,6 +60,5 @@ object CamundaBpmDataMockito {
      * @return verifier to simplify assertions.
      */
     @JvmStatic
-    fun runtimeServiceMockVerifier(runtimeService: RuntimeService)
-        = RuntimeServiceMockVerifier(runtimeService)
+    fun runtimeServiceMockVerifier(runtimeService: RuntimeService) = RuntimeServiceMockVerifier(runtimeService)
 }

--- a/mockito/src/main/kotlin/RuntimeServiceMockVerifier.kt
+++ b/mockito/src/main/kotlin/RuntimeServiceMockVerifier.kt
@@ -4,7 +4,6 @@ import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import io.holunda.camunda.bpm.data.factory.VariableFactory
 import org.camunda.bpm.engine.RuntimeService
-import org.camunda.bpm.engine.variable.VariableMap
 
 /**
  * Verifier for a mocked runtime service.

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.camunda.bpm.springboot</groupId>
+        <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
+        <version>${camunda-spring-boot.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -735,6 +741,9 @@
     </developer>
     <developer>
       <name>Jan Galinski</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
       <organization>Holisticon AG</organization>
       <organizationUrl>https://holisticon.de</organizationUrl>
     </developer>


### PR DESCRIPTION
This pr removes dependency declaration from example-parent and moves them to the java and kotlin example.

That way, the dependencies of an example app using camunda-bpm-data are clearly visible to anyone who inspects the code.