### PR TITLE
Variable verification without any services

### DIFF
--- a/extension/test/src/main/kotlin/CaseServiceMockVerifier.kt
+++ b/extension/test/src/main/kotlin/CaseServiceMockVerifier.kt
@@ -6,7 +6,7 @@ import io.holunda.camunda.bpm.data.factory.VariableFactory
 import org.camunda.bpm.engine.CaseService
 
 /**
- * Verifier for a mocked runtime service.
+ * Verifier for a mocked case service.
  * Provides methods for easy verification.
  */
 class CaseServiceMockVerifier(

--- a/extension/test/src/main/kotlin/VariableMockBuilder.kt
+++ b/extension/test/src/main/kotlin/VariableMockBuilder.kt
@@ -1,0 +1,24 @@
+package io.holunda.camunda.bpm.data.mockito
+
+import com.nhaarman.mockitokotlin2.whenever
+import io.holunda.camunda.bpm.data.factory.VariableFactory
+import org.camunda.bpm.engine.delegate.VariableScope
+
+/**
+ * Mocks process variables within a given Variable scope
+ */
+class VariableMockBuilder {
+  /**
+   * Mocks the given variable globally with the given value within the given @VariableScope
+   */
+  fun <T> set(variableScope: VariableScope, variable: VariableFactory<T>, value: T) {
+    whenever(variableScope.getVariable(variable.name)).thenReturn(value)
+  }
+
+  /**
+   * Mocks the given variable locally with the given value within the given @VariableScope
+   */
+  fun <T> setLocal(variableScope: VariableScope, variable: VariableFactory<T>, value: T) {
+    whenever(variableScope.getVariableLocal(variable.name)).thenReturn(value)
+  }
+}

--- a/extension/test/src/main/kotlin/VariableMockVerifier.kt
+++ b/extension/test/src/main/kotlin/VariableMockVerifier.kt
@@ -1,0 +1,165 @@
+package io.holunda.camunda.bpm.data.mockito
+
+import io.holunda.camunda.bpm.data.factory.VariableFactory
+import org.camunda.bpm.engine.delegate.VariableScope
+import org.camunda.bpm.engine.variable.Variables
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import java.util.Date
+
+/**
+ * Verifier for a mocked variable.
+ * Provides methods for easy verification.
+ */
+class VariableMockVerifier {
+
+  /**
+   * Verifies if the variable has been set globally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param value value to set.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableSet(variableScope: VariableScope, variable: VariableFactory<T>, value: T) {
+    when (value) {
+      is Boolean -> verify(variableScope).setVariable(variable.name, Variables.booleanValue(value as Boolean))
+      is Long -> verify(variableScope).setVariable(variable.name, Variables.longValue(value as Long))
+      is String -> verify(variableScope).setVariable(variable.name, Variables.stringValue(value as String))
+      is Date -> verify(variableScope).setVariable(variable.name, Variables.dateValue(value as Date))
+      else -> verify(variableScope).setVariable(variable.name, Variables.untypedValue(value))
+    }
+  }
+
+  /**
+   * Verifies if the variable has NOT been set globally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param value value to set.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableNotSet(variableScope: VariableScope, variable: VariableFactory<T>, value: T) {
+    when (value) {
+      is Boolean -> verify(variableScope, never()).setVariable(variable.name, Variables.booleanValue(value as Boolean))
+      is Long -> verify(variableScope, never()).setVariable(variable.name, Variables.longValue(value as Long))
+      is String -> verify(variableScope, never()).setVariable(variable.name, Variables.stringValue(value as String))
+      is Date -> verify(variableScope, never()).setVariable(variable.name, Variables.dateValue(value as Date))
+      else -> verify(variableScope, never()).setVariable(variable.name, Variables.untypedValue(value))
+    }
+  }
+
+  /**
+   * Verifies if the variable has been set locally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param value value to set.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableSetLocal(variableScope: VariableScope, variable: VariableFactory<T>, value: T) {
+    when (value) {
+      is Boolean -> verify(variableScope).setVariableLocal(variable.name, Variables.booleanValue(value as Boolean))
+      is Long -> verify(variableScope).setVariableLocal(variable.name, Variables.longValue(value as Long))
+      is String -> verify(variableScope).setVariableLocal(variable.name, Variables.stringValue(value as String))
+      is Date -> verify(variableScope).setVariableLocal(variable.name, Variables.dateValue(value as Date))
+      else -> verify(variableScope).setVariableLocal(variable.name, Variables.untypedValue(value))
+    }
+  }
+
+  /**
+   * Verifies if the variable has NOT been set locally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param value value to set.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableNotSetLocal(variableScope: VariableScope, variable: VariableFactory<T>, value: T) {
+    when (value) {
+      is Boolean -> verify(variableScope, never()).setVariableLocal(variable.name, Variables.booleanValue(value as Boolean))
+      is Long -> verify(variableScope, never()).setVariableLocal(variable.name, Variables.longValue(value as Long))
+      is String -> verify(variableScope, never()).setVariableLocal(variable.name, Variables.stringValue(value as String))
+      is Date -> verify(variableScope, never()).setVariableLocal(variable.name, Variables.dateValue(value as Date))
+      else -> verify(variableScope, never()).setVariableLocal(variable.name, Variables.untypedValue(value))
+    }
+  }
+
+  /**
+   * Verifies if the variable has been read globally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableGet(variableScope: VariableScope, variable: VariableFactory<T>) {
+    verify(variableScope).getVariable(variable.name)
+  }
+
+  /**
+   * Verifies if the variable has NOT been read globally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableNotGet(variableScope: VariableScope, variable: VariableFactory<T>) {
+    verify(variableScope, never()).getVariable(variable.name)
+  }
+
+
+  /**
+   * Verifies if the variable has been read locally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableGetLocal(variableScope: VariableScope, variable: VariableFactory<T>) {
+    verify(variableScope).getVariableLocal(variable.name)
+  }
+
+  /**
+   * Verifies if the variable has NOT been read locally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableNotGetLocal(variableScope: VariableScope, variable: VariableFactory<T>) {
+    verify(variableScope, never()).getVariableLocal(variable.name)
+  }
+
+  /**
+   * Verifies if the variable has been removed globally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableRemoved(variableScope: VariableScope, variable: VariableFactory<T>) {
+    verify(variableScope).removeVariable(variable.name)
+  }
+
+  /**
+   * Verifies if the variable has NOT been removed globally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableNotRemoved(variableScope: VariableScope, variable: VariableFactory<T>) {
+    verify(variableScope, never()).removeVariable(variable.name)
+  }
+
+
+  /**
+   * Verifies if the variable has been removed locally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableRemovedLocal(variableScope: VariableScope, variable: VariableFactory<T>) {
+    verify(variableScope).removeVariableLocal(variable.name)
+  }
+
+  /**
+   * Verifies if the variable has NOT been removed locally.
+   * @param variableScope scope the variable is defined in
+   * @param variable factory defining the variable.
+   * @param T type of variable.
+   */
+  fun <T> verifyVariableNotRemovedLocal(variableScope: VariableScope, variable: VariableFactory<T>) {
+    verify(variableScope, never()).removeVariableLocal(variable.name)
+  }
+}

--- a/extension/test/src/test/kotlin/VariableMockBuilderTest.kt
+++ b/extension/test/src/test/kotlin/VariableMockBuilderTest.kt
@@ -1,0 +1,38 @@
+package io.holunda.camunda.bpm.data.mockito
+
+import io.holunda.camunda.bpm.data.CamundaBpmData
+import org.assertj.core.api.Assertions.assertThat
+import org.camunda.bpm.engine.delegate.DelegateExecution
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+
+class VariableMockBuilderTest {
+
+  private val variableMockBuilder = VariableMockBuilder()
+  private val execution = mock(DelegateExecution::class.java)
+
+  @Test
+  fun `should set a variable globally`() {
+    // given
+    val variable = CamundaBpmData.stringVariable("stringVariable")
+
+    // when
+    variableMockBuilder.set(execution, variable, "global value")
+
+    // then
+    assertThat(variable.from(execution).get()).isEqualTo("global value")
+  }
+
+  @Test
+  fun `should set a variable locally`() {
+    // given
+    val variable = CamundaBpmData.stringVariable("stringVariable")
+
+    // when
+    variableMockBuilder.setLocal(execution, variable, "local Value")
+
+    // then
+    val value = variable.from(execution).local
+    assertThat(value).isEqualTo("local Value")
+  }
+}

--- a/extension/test/src/test/kotlin/VariableMockVerifierTest.kt
+++ b/extension/test/src/test/kotlin/VariableMockVerifierTest.kt
@@ -1,0 +1,854 @@
+package io.holunda.camunda.bpm.data.mockito
+
+import io.holunda.camunda.bpm.data.CamundaBpmData
+import io.holunda.camunda.bpm.data.factory.VariableFactory
+import org.camunda.bpm.engine.delegate.DelegateExecution
+import org.junit.Assert
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.exceptions.base.MockitoAssertionError
+import java.time.Instant
+import java.util.Date
+
+class VariableMockVerifierTest {
+
+  private var execution = Mockito.mock(DelegateExecution::class.java)
+
+  private val verifier = VariableMockVerifier()
+  private val builder = VariableMockBuilder()
+
+  @Nested
+  inner class GetChecks {
+    private val variable = CamundaBpmData.stringVariable("stringVariable")
+
+    @Nested
+    inner class Local {
+
+      @Test
+      fun `should verify expected read variable`() {
+        // given
+        builder.setLocal(execution, variable, "to successfully read you have to set it first")
+        variable.from(execution).local
+
+        // when
+        verifier.verifyVariableGetLocal(execution, variable)
+      }
+
+      @Test
+      fun `should detect expected but not read variable`() {
+        // given
+        // no variable was read
+
+        // when
+        try {
+          verifier.verifyVariableGetLocal(execution, variable)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should verify not expected and not read variable`() {
+        // given
+        // no variable gets read
+
+        // when
+        verifier.verifyVariableNotGetLocal(execution, variable)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but read variable`() {
+        // given
+        builder.setLocal(execution, variable, "to successfully read you have to set it first")
+        variable.from(execution).local
+
+        // when
+        try {
+          verifier.verifyVariableNotGetLocal(execution, variable)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+
+    @Nested
+    inner class Global {
+
+      @Test
+      fun `should verify expected read variable`() {
+        // given
+        builder.set(execution, variable, "to successfully read you have to set it first")
+        variable.from(execution).get()
+
+        // when
+        verifier.verifyVariableGet(execution, variable)
+      }
+
+      @Test
+      fun `should detect expected but not read variable`() {
+        // given
+        // no variable was read
+
+        // when
+        try {
+          verifier.verifyVariableGet(execution, variable)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should verify not expected and not read variable`() {
+        // given
+        // no variable gets read
+
+        // when
+        verifier.verifyVariableNotGet(execution, variable)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but read variable`() {
+        // given
+        builder.set(execution, variable, "to successfully read you have to set it first")
+        variable.from(execution).get()
+
+        // when
+        try {
+          verifier.verifyVariableNotGet(execution, variable)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class RemoveChecks {
+    private val variable = CamundaBpmData.stringVariable("stringVariable")
+
+    @Nested
+    inner class Local {
+
+      @Test
+      fun `should verify expected removed variable`() {
+        // given
+        variable.on(execution).removeLocal()
+
+        // when
+        verifier.verifyVariableRemovedLocal(execution, variable)
+      }
+
+      @Test
+      fun `should detect expected but not removed variable`() {
+        // given
+        // no variable gets removed
+
+        // when
+        try {
+          verifier.verifyVariableRemovedLocal(execution, variable)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should verify not expected and not removed variable`() {
+        // given
+        // no variable gets removed
+
+        // when
+        verifier.verifyVariableNotRemovedLocal(execution, variable)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but removed variable`() {
+        // given
+        variable.on(execution).removeLocal()
+
+        // when
+        try {
+          verifier.verifyVariableNotRemovedLocal(execution, variable)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+
+    @Nested
+    inner class Global {
+
+      @Test
+      fun `should verify expected removed variable`() {
+        // given
+        variable.on(execution).remove()
+
+        // when
+        verifier.verifyVariableRemoved(execution, variable)
+      }
+
+      @Test
+      fun `should detect expected but not removed variable`() {
+        // given
+        // no variable gets removed
+
+        // when
+        try {
+          verifier.verifyVariableRemoved(execution, variable)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should verify not expected and not removed variable`() {
+        // given
+        // no variable gets removed
+
+        // when
+        verifier.verifyVariableNotRemoved(execution, variable)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but removed variable`() {
+        // given
+        variable.on(execution).remove()
+
+        // when
+        try {
+          verifier.verifyVariableNotRemoved(execution, variable)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class BoolChecks {
+    private val booleanVariable = CamundaBpmData.booleanVariable("booleanVariable")
+
+    @Nested
+    inner class Local {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        booleanVariable.on(execution).setLocal(true)
+
+        // when
+        verifier.verifyVariableSetLocal(execution, booleanVariable, true)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSetLocal(execution, booleanVariable, true)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSetLocal(execution, booleanVariable, true)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        booleanVariable.on(execution).setLocal(true)
+
+        // when
+        try {
+          verifier.verifyVariableNotSetLocal(execution, booleanVariable, true)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+
+    @Nested
+    inner class Global {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        booleanVariable.on(execution).set(true)
+
+        // when
+        verifier.verifyVariableSet(execution, booleanVariable, true)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSet(execution, booleanVariable, true)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSet(execution, booleanVariable, true)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        booleanVariable.on(execution).set(true)
+
+        // when
+        try {
+          verifier.verifyVariableNotSet(execution, booleanVariable, true)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class StringChecks {
+    private val stringVariable = CamundaBpmData.stringVariable("stringVariable")
+
+    @Nested
+    inner class Local {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        stringVariable.on(execution).setLocal("string")
+
+        // when
+        verifier.verifyVariableSetLocal(execution, stringVariable, "string")
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSetLocal(execution, stringVariable, "string")
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSetLocal(execution, stringVariable, "string")
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        stringVariable.on(execution).setLocal("string")
+
+        // when
+        try {
+          verifier.verifyVariableNotSetLocal(execution, stringVariable, "string")
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+
+    @Nested
+    inner class Global {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        stringVariable.on(execution).set("string")
+
+        // when
+        verifier.verifyVariableSet(execution, stringVariable, "string")
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSet(execution, stringVariable, "string")
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSet(execution, stringVariable, "string")
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        stringVariable.on(execution).set("string")
+
+        // when
+        try {
+          verifier.verifyVariableNotSet(execution, stringVariable, "string")
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class LongChecks {
+    private val longVariable = CamundaBpmData.longVariable("longVariable")
+
+    @Nested
+    internal inner class Local {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        longVariable.on(execution).setLocal(1L)
+
+        // when
+        verifier.verifyVariableSetLocal(execution, longVariable, 1L)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSetLocal(execution, longVariable, 1L)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSetLocal(execution, longVariable, 1L)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        longVariable.on(execution).setLocal(1L)
+
+        // when
+        try {
+          verifier.verifyVariableNotSetLocal(execution, longVariable, 1L)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+
+    @Nested
+    internal inner class Global {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        longVariable.on(execution).set(1L)
+
+        // when
+        verifier.verifyVariableSet(execution, longVariable, 1L)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSet(execution, longVariable, 1L)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSet(execution, longVariable, 1L)
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        longVariable.on(execution).set(1L)
+
+        // when
+        try {
+          verifier.verifyVariableNotSet(execution, longVariable, 1L)
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class DateChecks {
+    private val dateVariable = CamundaBpmData.dateVariable("dateVariable")
+
+    @Nested
+    internal inner class Local {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        dateVariable.on(execution).setLocal(Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+
+        // when
+        verifier.verifyVariableSetLocal(execution, dateVariable, Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSetLocal(execution, dateVariable, Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSetLocal(execution, dateVariable, Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        dateVariable.on(execution).setLocal(Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+
+        // when
+        try {
+          verifier.verifyVariableNotSetLocal(execution, dateVariable, Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+
+    @Nested
+    internal inner class Global {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        dateVariable.on(execution).set(Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+
+        // when
+        verifier.verifyVariableSet(execution, dateVariable, Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSet(execution, dateVariable, Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSet(execution, dateVariable, Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        dateVariable.on(execution).set(Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+
+        // when
+        try {
+          verifier.verifyVariableNotSet(execution, dateVariable, Date.from(Instant.parse("2020-07-24T12:00:00Z")))
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+  }
+
+  data class TestClass(
+    private val property: String = "test"
+  )
+
+  @Nested
+  inner class CustomChecks {
+
+    private val customVariable: VariableFactory<TestClass> = CamundaBpmData.customVariable("customVariable", TestClass::class.java)
+
+    @Nested
+    internal inner class Local {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        customVariable.on(execution).setLocal(TestClass())
+
+        // when
+        verifier.verifyVariableSetLocal(execution, customVariable, TestClass())
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSetLocal(execution, customVariable, TestClass())
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSetLocal(execution, customVariable, TestClass())
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        customVariable.on(execution).setLocal(TestClass())
+
+        // when
+        try {
+          verifier.verifyVariableNotSetLocal(execution, customVariable, TestClass())
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+
+    @Nested
+    internal inner class Global {
+      @Test
+      fun `should verify expected and set values`() {
+        // given
+        customVariable.on(execution).set(TestClass())
+
+        // when
+        verifier.verifyVariableSet(execution, customVariable, TestClass())
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should verify not expected and not set value`() {
+        // given
+        // no variable is set
+
+        // when
+        try {
+          verifier.verifyVariableSet(execution, customVariable, TestClass())
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+
+      @Test
+      fun `should detect expected but not set values`() {
+        // given
+        // no variable is set
+
+        // when
+        verifier.verifyVariableNotSet(execution, customVariable, TestClass())
+
+        // then
+        // no Exception
+      }
+
+      @Test
+      fun `should detect not expected but set values`() {
+        // given
+        customVariable.on(execution).set(TestClass())
+
+        // when
+        try {
+          verifier.verifyVariableNotSet(execution, customVariable, TestClass())
+          Assert.fail("Verification should fail")
+        } catch (ignore: MockitoAssertionError) {
+          // then
+          // Assertion hits
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
If you just want to test interactions with process variables **without** any service (RuntimeService, TaskService, ...) the existing helpers in `camunda-bpm-data-test` didn't matched. The new added `VariableMockVerifier` help to test that e.g. a delegate stores data in a specific process variable via a VariableScope object instead of via services;

```  
    @Component
    public class LoadImportantDataDelegate implements JavaDelegate {
    
      @Autowire
      private final ImportantDataService importantDataService;
    
      public void execute(DelegateExecution execution) {
    	    String importantData = importantDataService.getData();
    	    IMPORTANT_DATA.on(execution).set(importantData); // this needs to be tested
        }
    }

```

The interactions with a process variable can now be tested via a `VariableMockVerifier` instance:

```
    @Test
    fun should_store_important_data() {
        val importantData = CamundaBpmData.stringVariable("importantData")
        // given
        whenever(importantDataService.getData()).thenReturn("holisticon for president")

        // when
        importantDataService.execute(execution)

        // then
        variableMockVerifier.verifyVariableSet(execution, IMPORTANT_VARIABLE.name, "holisticon for president")
    }

```

The verification methods now hide the handling of the type of the process variable, which otherwise must be handled manually to match within an assertion.

Attention: the tests are done with JUnit 5, not 4