### PR TITLE
Allow nullable types in Kotlin

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -10,9 +10,7 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -33,12 +31,15 @@ jobs:
     - name: Run integration tests and generate coverage reports
       run: ./mvnw -Pitest verify failsafe:verify -ntp
 
+  coverage:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
     - name: Upload coverage to Codecov
       if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
       uses: codecov/codecov-action@v3
       with:
         token: ${{secrets.CODECOV_TOKEN}}
-
     - name: Upload test coverage to Codacy
       if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
       run: bash <(curl -Ls https://coverage.codacy.com/get.sh)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,9 +6,7 @@ on:
     - master
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -23,13 +21,6 @@ jobs:
         server-username: OSS_CENTRAL_USERNAME # env variable for Maven Central
         server-password: OSS_CENTRAL_PASSWORD # env variable for Maven Central
 
-    # Get GPG private key into GPG
-    - name: Import GPG Owner Trust
-      run: echo ${{ secrets.GPG_OWNERTRUST }} | base64 --decode | gpg --import-ownertrust
-
-    - name: Import GPG key
-      run: echo ${{ secrets.GPG_SECRET_KEYS }} | base64 --decode | gpg --import --no-tty --batch --yes
-
     - name: Prepare mvnw
       run: chmod +x ./mvnw
 
@@ -39,12 +30,27 @@ jobs:
     - name: Run integration tests and generate coverage reports
       run: ./mvnw -Pitest verify failsafe:verify
 
+  deploy:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      # Get GPG private key into GPG
+    - name: Import GPG Owner Trust
+      run: echo ${{ secrets.GPG_OWNERTRUST }} | base64 --decode | gpg --import-ownertrust
+
+    - name: Import GPG key
+      run: echo ${{ secrets.GPG_SECRET_KEYS }} | base64 --decode | gpg --import --no-tty --batch --yes
+
     - name: Deploy a new version to central
       run: ./mvnw clean deploy -B -DskipTests -DskipExamples -Prelease -Dgpg.keyname="${{secrets.GPG_KEYNAME}}" -Dgpg.passphrase="${{secrets.GPG_PASSPHRASE}}"
       env:
         OSS_CENTRAL_USERNAME: "${{ secrets.SONATYPE_USERNAME }}"
         OSS_CENTRAL_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"
 
+  coverage:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
     - name: Upload test coverage to Codacy
       if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
       run: bash <(curl -Ls https://coverage.codacy.com/get.sh)

--- a/example/example-kotlin/src/main/kotlin/process/OrderApproval.kt
+++ b/example/example-kotlin/src/main/kotlin/process/OrderApproval.kt
@@ -67,7 +67,7 @@ class OrderApproval {
   fun calculateOrderPositions() = JavaDelegate { execution ->
     val orderPosition = ORDER_POSITION.from(execution).get()
 
-    ORDER_TOTAL.on(execution).update { total -> total.plus(orderPosition.netCost.times(BigDecimal.valueOf(orderPosition.amount))) }
+    ORDER_TOTAL.on(execution).update { total -> total?.plus(orderPosition.netCost.times(BigDecimal.valueOf(orderPosition.amount))) }
   }
 
   /**

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/VariableFactoryFluentApi.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/VariableFactoryFluentApi.kt
@@ -44,7 +44,7 @@ fun <T> VariableMap.remove(factory: VariableFactory<T>) = this.apply {
  * @param valueProcessor update function.
  * @param isTransient flag for transient access, <code>false</code> by default.
  */
-fun <T> VariableMap.update(factory: VariableFactory<T>, valueProcessor: (T) -> T, isTransient: Boolean = false) = this.apply {
+fun <T> VariableMap.update(factory: VariableFactory<T>, valueProcessor: (T?) -> T?, isTransient: Boolean = false) = this.apply {
   factory.on(this).update(valueProcessor, isTransient)
 }
 
@@ -90,7 +90,7 @@ fun <T> VariableScope.remove(factory: VariableFactory<T>) = this.apply {
  * @param valueProcessor update function.
  * @param isTransient flag for transient access, <code>false</code> by default.
  */
-fun <T> VariableScope.update(factory: VariableFactory<T>, valueProcessor: (T) -> T, isTransient: Boolean = false) = this.apply {
+fun <T> VariableScope.update(factory: VariableFactory<T>, valueProcessor: (T?) -> T?, isTransient: Boolean = false) = this.apply {
   factory.on(this).update(valueProcessor, isTransient)
 }
 
@@ -118,7 +118,7 @@ fun <T> VariableScope.removeLocal(factory: VariableFactory<T>) = this.apply {
  * @param valueProcessor update function.
  * @param isTransient flag for transient access, <code>false</code> by default.
  */
-fun <T> VariableScope.updateLocal(factory: VariableFactory<T>, valueProcessor: (T) -> T, isTransient: Boolean = false) = this.apply {
+fun <T> VariableScope.updateLocal(factory: VariableFactory<T>, valueProcessor: (T?) -> T?, isTransient: Boolean = false) = this.apply {
   factory.on(this).updateLocal(valueProcessor, isTransient)
 }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/AbstractReadWriteAdapter.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/AbstractReadWriteAdapter.kt
@@ -9,11 +9,11 @@ import java.util.function.Function
  * @param variableName variable name,
  */
 abstract class AbstractReadWriteAdapter<T>(protected val variableName: String) : ReadAdapter<T>, WriteAdapter<T> {
-    override fun set(value: T) {
+    override fun set(value: T?) {
         set(value, false)
     }
 
-    override fun setLocal(value: T) {
+    override fun setLocal(value: T?) {
         setLocal(value, false)
     }
 
@@ -25,7 +25,7 @@ abstract class AbstractReadWriteAdapter<T>(protected val variableName: String) :
         return getLocalOptional().orElseThrow { VariableNotFoundException("Couldn't find required local variable '$variableName'") }
     }
 
-    override fun update(valueProcessor: Function<T, T>, isTransient: Boolean) {
+    override fun update(valueProcessor: Function<T?, T?>, isTransient: Boolean) {
         val oldValue = get()
         val newValue = valueProcessor.apply(oldValue)
         if (oldValue != newValue) {
@@ -34,7 +34,7 @@ abstract class AbstractReadWriteAdapter<T>(protected val variableName: String) :
         }
     }
 
-    override fun updateLocal(valueProcessor: Function<T, T>, isTransient: Boolean) {
+    override fun updateLocal(valueProcessor: Function<T?, T?>, isTransient: Boolean) {
         val oldValue = getLocal()
         val newValue = valueProcessor.apply(oldValue)
         if (oldValue != newValue) {
@@ -43,11 +43,11 @@ abstract class AbstractReadWriteAdapter<T>(protected val variableName: String) :
         }
     }
 
-    override fun update(valueProcessor: Function<T, T>) {
+    override fun update(valueProcessor: Function<T?, T?>) {
         update(valueProcessor, false)
     }
 
-    override fun updateLocal(valueProcessor: Function<T, T>) {
+    override fun updateLocal(valueProcessor: Function<T?, T?>) {
         updateLocal(valueProcessor, false)
     }
 }

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/WriteAdapter.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/WriteAdapter.kt
@@ -14,7 +14,7 @@ interface WriteAdapter<T> {
      *
      * @param value value to write.
      */
-    fun set(value: T)
+    fun set(value: T?)
 
     /**
      * Writes a value as a transient variable.
@@ -22,14 +22,14 @@ interface WriteAdapter<T> {
      * @param value       value to write.
      * @param isTransient allows to specify if the variable is transient.
      */
-    operator fun set(value: T, isTransient: Boolean)
+    operator fun set(value: T?, isTransient: Boolean)
 
     /**
      * Writes a local variable.
      *
      * @param value value to write.
      */
-    fun setLocal(value: T)
+    fun setLocal(value: T?)
 
     /**
      * Writes a local variable.
@@ -37,7 +37,7 @@ interface WriteAdapter<T> {
      * @param value       value to write.
      * @param isTransient allows to specify if the variable is transient.
      */
-    fun setLocal(value: T, isTransient: Boolean)
+    fun setLocal(value: T?, isTransient: Boolean)
 
     /**
      * Removes a variable from the scope.
@@ -55,7 +55,7 @@ interface WriteAdapter<T> {
      *
      * @param valueProcessor function updating the value based on the old value.
      */
-    fun update(valueProcessor: Function<T, T>)
+    fun update(valueProcessor: Function<T?, T?>)
 
     /**
      * Updates a local variable using provided value processor.
@@ -63,7 +63,7 @@ interface WriteAdapter<T> {
      *
      * @param valueProcessor function updating the value based on the old value.
      */
-    fun updateLocal(valueProcessor: Function<T, T>)
+    fun updateLocal(valueProcessor: Function<T?, T?>)
 
     /**
      * Updates a variable using provided value processor.
@@ -72,7 +72,7 @@ interface WriteAdapter<T> {
      * @param valueProcessor function updating the value based on the old value.
      * @param isTransient    transient flag.
      */
-    fun update(valueProcessor: Function<T, T>, isTransient: Boolean)
+    fun update(valueProcessor: Function<T?, T?>, isTransient: Boolean)
 
     /**
      * Updates a local variable using provided value processor.
@@ -81,7 +81,7 @@ interface WriteAdapter<T> {
      * @param valueProcessor function updating the value based on the old value.
      * @param isTransient    transient flag.
      */
-    fun updateLocal(valueProcessor: Function<T, T>, isTransient: Boolean)
+    fun updateLocal(valueProcessor: Function<T?, T?>, isTransient: Boolean)
 
     /**
      * Constructs typed value.

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadAdapterLockedExternalTask.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadAdapterLockedExternalTask.kt
@@ -26,11 +26,11 @@ class ReadAdapterLockedExternalTask<T : Any>(
     )
   }
 
-  override fun set(value: T, isTransient: Boolean) {
+  override fun set(value: T?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a variable on an external task")
   }
 
-  override fun setLocal(value: T, isTransient: Boolean) {
+  override fun setLocal(value: T?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a local variable on an external task")
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterCaseService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterCaseService.kt
@@ -23,7 +23,7 @@ class ReadWriteAdapterCaseService<T : Any>(
     return Optional.ofNullable(getOrNull(caseService.getVariable(caseExecutionId, variableName)))
   }
 
-  override fun set(value: T, isTransient: Boolean) {
+  override fun set(value: T?, isTransient: Boolean) {
     caseService.setVariable(caseExecutionId, variableName, getTypedValue(value, isTransient))
   }
 
@@ -31,7 +31,7 @@ class ReadWriteAdapterCaseService<T : Any>(
     return Optional.ofNullable(getOrNull(caseService.getVariableLocal(caseExecutionId, variableName)))
   }
 
-  override fun setLocal(value: T, isTransient: Boolean) {
+  override fun setLocal(value: T?, isTransient: Boolean) {
     caseService.setVariableLocal(caseExecutionId, variableName, getTypedValue(value, isTransient))
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterRuntimeService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterRuntimeService.kt
@@ -22,7 +22,7 @@ class ReadWriteAdapterRuntimeService<T : Any>(
     return Optional.ofNullable(getOrNull(runtimeService.getVariable(executionId, variableName)))
   }
 
-  override fun set(value: T, isTransient: Boolean) {
+  override fun set(value: T?, isTransient: Boolean) {
     runtimeService.setVariable(executionId, variableName, getTypedValue(value, isTransient))
   }
 
@@ -30,7 +30,7 @@ class ReadWriteAdapterRuntimeService<T : Any>(
     return Optional.ofNullable(getOrNull(runtimeService.getVariableLocal(executionId, variableName)))
   }
 
-  override fun setLocal(value: T, isTransient: Boolean) {
+  override fun setLocal(value: T?, isTransient: Boolean) {
     runtimeService.setVariableLocal(executionId, variableName, getTypedValue(value, isTransient))
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterTaskService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterTaskService.kt
@@ -22,7 +22,7 @@ class ReadWriteAdapterTaskService<T: Any>(
         return Optional.ofNullable(getOrNull(taskService.getVariable(taskId, variableName)))
     }
 
-    override fun set(value: T, isTransient: Boolean) {
+    override fun set(value: T?, isTransient: Boolean) {
         taskService.setVariable(taskId, variableName, getTypedValue(value, isTransient))
     }
 
@@ -30,7 +30,7 @@ class ReadWriteAdapterTaskService<T: Any>(
         return Optional.ofNullable(getOrNull(taskService.getVariableLocal(taskId, variableName)))
     }
 
-    override fun setLocal(value: T, isTransient: Boolean) {
+    override fun setLocal(value: T?, isTransient: Boolean) {
         taskService.setVariableLocal(taskId, variableName, getTypedValue(value, isTransient))
     }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableMap.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableMap.kt
@@ -18,7 +18,7 @@ class ReadWriteAdapterVariableMap<T : Any>(private val variableMap: VariableMap,
     return Optional.ofNullable(getOrNull(variableMap[variableName]))
   }
 
-  override fun set(value: T, isTransient: Boolean) {
+  override fun set(value: T?, isTransient: Boolean) {
     variableMap.putValueTyped(variableName, getTypedValue(value, isTransient))
   }
 
@@ -26,7 +26,7 @@ class ReadWriteAdapterVariableMap<T : Any>(private val variableMap: VariableMap,
     throw UnsupportedOperationException("Can't get a local variable on a variable map")
   }
 
-  override fun setLocal(value: T, isTransient: Boolean) {
+  override fun setLocal(value: T?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a local variable on a variable map")
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableScope.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableScope.kt
@@ -16,7 +16,7 @@ class ReadWriteAdapterVariableScope<T: Any>(
   variableName: String,
   clazz: Class<T>
 ) : AbstractBasicReadWriteAdapter<T>(variableName, clazz) {
-  override fun set(value: T, isTransient: Boolean) {
+  override fun set(value: T?, isTransient: Boolean) {
     variableScope.setVariable(variableName, getTypedValue(value, isTransient))
   }
 
@@ -24,7 +24,7 @@ class ReadWriteAdapterVariableScope<T: Any>(
     return Optional.ofNullable(getOrNull(variableScope.getVariableLocal(variableName)))
   }
 
-  override fun setLocal(value: T, isTransient: Boolean) {
+  override fun setLocal(value: T?, isTransient: Boolean) {
     variableScope.setVariableLocal(variableName, getTypedValue(value, isTransient))
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadAdapterLockedExternalTask.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadAdapterLockedExternalTask.kt
@@ -27,11 +27,11 @@ class ListReadAdapterLockedExternalTask<T>(
     )
   }
 
-  override fun set(value: List<T>, isTransient: Boolean) {
+  override fun set(value: List<T>?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a variable on an external task")
   }
 
-  override fun setLocal(value: List<T>, isTransient: Boolean) {
+  override fun setLocal(value: List<T>?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a local variable on an external task")
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterCaseService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterCaseService.kt
@@ -29,8 +29,8 @@ class ListReadWriteAdapterCaseService<T>(
     )
   }
 
-  override fun set(value: List<T>, isTransient: Boolean) {
-    caseService.setVariable(caseExecutionId, variableName, getTypedValue(value, isTransient))
+  override fun set(value: List<T>?, isTransient: Boolean) {
+    caseService.setVariable(caseExecutionId, variableName, getTypedValue(value ?: listOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<List<T>> {
@@ -43,8 +43,8 @@ class ListReadWriteAdapterCaseService<T>(
     )
   }
 
-  override fun setLocal(value: List<T>, isTransient: Boolean) {
-    caseService.setVariableLocal(caseExecutionId, variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: List<T>?, isTransient: Boolean) {
+    caseService.setVariableLocal(caseExecutionId, variableName, getTypedValue(value ?: listOf<T>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterRuntimeService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterRuntimeService.kt
@@ -29,8 +29,8 @@ class ListReadWriteAdapterRuntimeService<T>(
     )
   }
 
-  override fun set(value: List<T>, isTransient: Boolean) {
-    runtimeService.setVariable(executionId, variableName, getTypedValue(value, isTransient))
+  override fun set(value: List<T>?, isTransient: Boolean) {
+    runtimeService.setVariable(executionId, variableName, getTypedValue(value ?: listOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<List<T>> {
@@ -43,8 +43,8 @@ class ListReadWriteAdapterRuntimeService<T>(
     )
   }
 
-  override fun setLocal(value: List<T>, isTransient: Boolean) {
-    runtimeService.setVariableLocal(executionId, variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: List<T>?, isTransient: Boolean) {
+    runtimeService.setVariableLocal(executionId, variableName, getTypedValue(value ?: listOf<T>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterTaskService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterTaskService.kt
@@ -23,16 +23,16 @@ class ListReadWriteAdapterTaskService<T>(
     return Optional.ofNullable(getOrNull(taskService.getVariable(taskId, variableName)))
   }
 
-  override fun set(value: List<T>, isTransient: Boolean) {
-    taskService.setVariable(taskId, variableName, getTypedValue(value, isTransient))
+  override fun set(value: List<T>?, isTransient: Boolean) {
+    taskService.setVariable(taskId, variableName, getTypedValue(value ?: listOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<List<T>> {
     return Optional.ofNullable(getOrNull(taskService.getVariableLocal(taskId, variableName)))
   }
 
-  override fun setLocal(value: List<T>, isTransient: Boolean) {
-    taskService.setVariableLocal(taskId, variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: List<T>?, isTransient: Boolean) {
+    taskService.setVariableLocal(taskId, variableName, getTypedValue(value ?: listOf<T>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterVariableMap.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterVariableMap.kt
@@ -22,15 +22,15 @@ class ListReadWriteAdapterVariableMap<T>(
     return Optional.ofNullable(getOrNull(variableMap[variableName]))
   }
 
-  override fun set(value: List<T>, isTransient: Boolean) {
-    variableMap.putValueTyped(variableName, getTypedValue(value, isTransient))
+  override fun set(value: List<T>?, isTransient: Boolean) {
+    variableMap.putValueTyped(variableName, getTypedValue(value ?: listOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<List<T>> {
     throw UnsupportedOperationException("Can't get a local variable on a variable map")
   }
 
-  override fun setLocal(value: List<T>, isTransient: Boolean) {
+  override fun setLocal(value: List<T>?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a local variable on a variable map")
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterVariableScope.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/list/ListReadWriteAdapterVariableScope.kt
@@ -21,16 +21,16 @@ class ListReadWriteAdapterVariableScope<T>(
     return Optional.ofNullable(getOrNull(variableScope.getVariable(variableName)))
   }
 
-  override fun set(value: List<T>, isTransient: Boolean) {
-    variableScope.setVariable(variableName, getTypedValue(value, isTransient))
+  override fun set(value: List<T>?, isTransient: Boolean) {
+    variableScope.setVariable(variableName, getTypedValue(value ?: listOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<List<T>> {
     return Optional.ofNullable(getOrNull(variableScope.getVariableLocal(variableName)))
   }
 
-  override fun setLocal(value: List<T>, isTransient: Boolean) {
-    variableScope.setVariableLocal(variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: List<T>?, isTransient: Boolean) {
+    variableScope.setVariableLocal(variableName, getTypedValue(value ?: listOf<T>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadAdapterLockedExternalTask.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadAdapterLockedExternalTask.kt
@@ -55,11 +55,11 @@ class MapReadAdapterLockedExternalTask<K, V>(
     throw UnsupportedOperationException("Can't remove a local variable on an external task")
   }
 
-  override fun set(value: Map<K, V>, isTransient: Boolean) {
+  override fun set(value: Map<K, V>?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a variable on an external task")
   }
 
-  override fun setLocal(value: Map<K, V>, isTransient: Boolean) {
+  override fun setLocal(value: Map<K, V>?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a local variable on an external task")
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterCaseService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterCaseService.kt
@@ -31,8 +31,8 @@ class MapReadWriteAdapterCaseService<K, V>(
         )
     }
 
-    override fun set(value: Map<K, V>, isTransient: Boolean) {
-        caseService.setVariable(caseExecutionId, variableName, getTypedValue(value, isTransient))
+    override fun set(value: Map<K, V>?, isTransient: Boolean) {
+        caseService.setVariable(caseExecutionId, variableName, getTypedValue(value ?: mapOf<K,V>(), isTransient))
     }
 
     override fun getLocalOptional(): Optional<Map<K, V>> {
@@ -45,8 +45,8 @@ class MapReadWriteAdapterCaseService<K, V>(
         )
     }
 
-    override fun setLocal(value: Map<K, V>, isTransient: Boolean) {
-        caseService.setVariableLocal(caseExecutionId, variableName, getTypedValue(value, isTransient))
+    override fun setLocal(value: Map<K, V>?, isTransient: Boolean) {
+        caseService.setVariableLocal(caseExecutionId, variableName, getTypedValue(value ?: mapOf<K,V>(), isTransient))
     }
 
     override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterRuntimeService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterRuntimeService.kt
@@ -31,8 +31,8 @@ class MapReadWriteAdapterRuntimeService<K, V>(
     )
   }
 
-  override fun set(value: Map<K, V>, isTransient: Boolean) {
-    runtimeService.setVariable(executionId, variableName, getTypedValue(value, isTransient))
+  override fun set(value: Map<K, V>?, isTransient: Boolean) {
+    runtimeService.setVariable(executionId, variableName, getTypedValue(value ?: mapOf<K,V>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<Map<K, V>> {
@@ -45,8 +45,8 @@ class MapReadWriteAdapterRuntimeService<K, V>(
     )
   }
 
-  override fun setLocal(value: Map<K, V>, isTransient: Boolean) {
-    runtimeService.setVariableLocal(executionId, variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: Map<K, V>?, isTransient: Boolean) {
+    runtimeService.setVariableLocal(executionId, variableName, getTypedValue(value ?: mapOf<K,V>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterTaskService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterTaskService.kt
@@ -25,16 +25,16 @@ class MapReadWriteAdapterTaskService<K, V>(
     return Optional.ofNullable(getOrNull(taskService.getVariable(taskId, variableName)))
   }
 
-  override fun set(value: Map<K, V>, isTransient: Boolean) {
-    taskService.setVariable(taskId, variableName, getTypedValue(value, isTransient))
+  override fun set(value: Map<K, V>?, isTransient: Boolean) {
+    taskService.setVariable(taskId, variableName, getTypedValue(value ?: mapOf<K,V>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<Map<K, V>> {
     return Optional.ofNullable(getOrNull(taskService.getVariableLocal(taskId, variableName)))
   }
 
-  override fun setLocal(value: Map<K, V>, isTransient: Boolean) {
-    taskService.setVariableLocal(taskId, variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: Map<K, V>?, isTransient: Boolean) {
+    taskService.setVariableLocal(taskId, variableName, getTypedValue(value ?: mapOf<K,V>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterVariableMap.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterVariableMap.kt
@@ -23,15 +23,15 @@ class MapReadWriteAdapterVariableMap<K, V>(
     return Optional.ofNullable(getOrNull(variableMap[variableName]))
   }
 
-  override fun set(value: Map<K, V>, isTransient: Boolean) {
-    variableMap.putValueTyped(variableName, getTypedValue(value, isTransient))
+  override fun set(value: Map<K, V>?, isTransient: Boolean) {
+    variableMap.putValueTyped(variableName, getTypedValue(value ?: mapOf<K,V>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<Map<K, V>> {
     throw UnsupportedOperationException("Can't get a local variable on a variable map")
   }
 
-  override fun setLocal(value: Map<K, V>, isTransient: Boolean) {
+  override fun setLocal(value: Map<K, V>?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a local variable on a variable map")
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterVariableScope.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/map/MapReadWriteAdapterVariableScope.kt
@@ -23,16 +23,16 @@ class MapReadWriteAdapterVariableScope<K, V>(
     return Optional.ofNullable(getOrNull(variableScope.getVariable(variableName)))
   }
 
-  override fun set(value: Map<K, V>, isTransient: Boolean) {
-    variableScope.setVariable(variableName, getTypedValue(value, isTransient))
+  override fun set(value: Map<K, V>?, isTransient: Boolean) {
+    variableScope.setVariable(variableName, getTypedValue(value ?: mapOf<K,V>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<Map<K, V>> {
     return Optional.ofNullable(getOrNull(variableScope.getVariableLocal(variableName)))
   }
 
-  override fun setLocal(value: Map<K, V>, isTransient: Boolean) {
-    variableScope.setVariableLocal(variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: Map<K, V>?, isTransient: Boolean) {
+    variableScope.setVariableLocal(variableName, getTypedValue(value ?: mapOf<K,V>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadAdapterLockedExternalTask.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadAdapterLockedExternalTask.kt
@@ -27,11 +27,11 @@ class SetReadAdapterLockedExternalTask<T>(
     )
   }
 
-  override fun set(value: Set<T>, isTransient: Boolean) {
+  override fun set(value: Set<T>?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a variable on an external task")
   }
 
-  override fun setLocal(value: Set<T>, isTransient: Boolean) {
+  override fun setLocal(value: Set<T>?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a local variable on an external task")
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterCaseService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterCaseService.kt
@@ -28,8 +28,8 @@ class SetReadWriteAdapterCaseService<T>(
     )
   }
 
-  override fun set(value: Set<T>, isTransient: Boolean) {
-    caseService.setVariable(caseExecutionId, variableName, getTypedValue(value, isTransient))
+  override fun set(value: Set<T>?, isTransient: Boolean) {
+    caseService.setVariable(caseExecutionId, variableName, getTypedValue(value ?: setOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<Set<T>> {
@@ -42,8 +42,8 @@ class SetReadWriteAdapterCaseService<T>(
     )
   }
 
-  override fun setLocal(value: Set<T>, isTransient: Boolean) {
-    caseService.setVariableLocal(caseExecutionId, variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: Set<T>?, isTransient: Boolean) {
+    caseService.setVariableLocal(caseExecutionId, variableName, getTypedValue(value ?: setOf<T>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterRuntimeService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterRuntimeService.kt
@@ -22,8 +22,8 @@ class SetReadWriteAdapterRuntimeService<T>(
     return Optional.ofNullable(getOrNull(runtimeService.getVariable(executionId, variableName)))
   }
 
-  override fun set(value: Set<T>, isTransient: Boolean) {
-    runtimeService.setVariable(executionId, variableName, getTypedValue(value, isTransient))
+  override fun set(value: Set<T>?, isTransient: Boolean) {
+    runtimeService.setVariable(executionId, variableName, getTypedValue(value ?: setOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<Set<T>> {
@@ -36,8 +36,8 @@ class SetReadWriteAdapterRuntimeService<T>(
     )
   }
 
-  override fun setLocal(value: Set<T>, isTransient: Boolean) {
-    runtimeService.setVariableLocal(executionId, variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: Set<T>?, isTransient: Boolean) {
+    runtimeService.setVariableLocal(executionId, variableName, getTypedValue(value ?: setOf<T>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterTaskService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterTaskService.kt
@@ -22,16 +22,16 @@ class SetReadWriteAdapterTaskService<T>(
     return Optional.ofNullable(getOrNull(taskService.getVariable(taskId, variableName)))
   }
 
-  override fun set(value: Set<T>, isTransient: Boolean) {
-    taskService.setVariable(taskId, variableName, getTypedValue(value, isTransient))
+  override fun set(value: Set<T>?, isTransient: Boolean) {
+    taskService.setVariable(taskId, variableName, getTypedValue(value ?: setOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<Set<T>> {
     return Optional.ofNullable(getOrNull(taskService.getVariableLocal(taskId, variableName)))
   }
 
-  override fun setLocal(value: Set<T>, isTransient: Boolean) {
-    taskService.setVariableLocal(taskId, variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: Set<T>?, isTransient: Boolean) {
+    taskService.setVariableLocal(taskId, variableName, getTypedValue(value ?: setOf<T>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterVariableMap.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterVariableMap.kt
@@ -20,15 +20,15 @@ class SetReadWriteAdapterVariableMap<T>(
     return Optional.ofNullable(getOrNull(variableMap[variableName]))
   }
 
-  override fun set(value: Set<T>, isTransient: Boolean) {
-    variableMap.putValueTyped(variableName, getTypedValue(value, isTransient))
+  override fun set(value: Set<T>?, isTransient: Boolean) {
+    variableMap.putValueTyped(variableName, getTypedValue(value ?: setOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<Set<T>> {
     throw UnsupportedOperationException("Can't get a local variable on a variable map")
   }
 
-  override fun setLocal(value: Set<T>, isTransient: Boolean) {
+  override fun setLocal(value: Set<T>?, isTransient: Boolean) {
     throw UnsupportedOperationException("Can't set a local variable on a variable map")
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterVariableScope.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/set/SetReadWriteAdapterVariableScope.kt
@@ -20,16 +20,16 @@ class SetReadWriteAdapterVariableScope<T>(
     return Optional.ofNullable(getOrNull(variableScope.getVariable(variableName)))
   }
 
-  override fun set(value: Set<T>, isTransient: Boolean) {
-    variableScope.setVariable(variableName, getTypedValue(value, isTransient))
+  override fun set(value: Set<T>?, isTransient: Boolean) {
+    variableScope.setVariable(variableName, getTypedValue(value ?: setOf<T>(), isTransient))
   }
 
   override fun getLocalOptional(): Optional<Set<T>> {
     return Optional.ofNullable(getOrNull(variableScope.getVariableLocal(variableName)))
   }
 
-  override fun setLocal(value: Set<T>, isTransient: Boolean) {
-    variableScope.setVariableLocal(variableName, getTypedValue(value, isTransient))
+  override fun setLocal(value: Set<T>?, isTransient: Boolean) {
+    variableScope.setVariableLocal(variableName, getTypedValue(value ?: setOf<T>(), isTransient))
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/CaseServiceVariableWriter.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/CaseServiceVariableWriter.kt
@@ -20,34 +20,34 @@ class CaseServiceVariableWriter(private val caseService: CaseService, private va
     return caseService.getVariablesLocalTyped(caseExecutionId)
   }
 
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T): CaseServiceVariableWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?): CaseServiceVariableWriter {
     return this.set(variableFactory, value, false)
   }
 
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): CaseServiceVariableWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): CaseServiceVariableWriter {
     variableFactory.on(caseService, caseExecutionId)[value] = isTransient
     return this
   }
 
-  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T): CaseServiceVariableWriter {
+  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T?): CaseServiceVariableWriter {
     return this.setLocal(variableFactory, value, false)
   }
 
-  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): CaseServiceVariableWriter {
+  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): CaseServiceVariableWriter {
     variableFactory.on(caseService, caseExecutionId).setLocal(value, isTransient)
     return this
   }
 
   override fun <T> updateLocal(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>
+    valueProcessor: Function<T?, T?>
   ): CaseServiceVariableWriter {
     return updateLocal(variableFactory, valueProcessor, false)
   }
 
   override fun <T> updateLocal(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>,
+    valueProcessor: Function<T?, T?>,
     isTransient: Boolean
   ): CaseServiceVariableWriter {
     variableFactory.on(caseService, caseExecutionId).updateLocal(valueProcessor, isTransient)
@@ -64,14 +64,14 @@ class CaseServiceVariableWriter(private val caseService: CaseService, private va
     return this
   }
 
-  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>): CaseServiceVariableWriter {
+  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>): CaseServiceVariableWriter {
     variableFactory.on(caseService, caseExecutionId).update(valueProcessor)
     return this
   }
 
   override fun <T> update(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>,
+    valueProcessor: Function<T?, T?>,
     isTransient: Boolean
   ): CaseServiceVariableWriter {
     variableFactory.on(caseService, caseExecutionId).updateLocal(valueProcessor, isTransient)

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/GlobalVariableWriter.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/GlobalVariableWriter.kt
@@ -19,7 +19,7 @@ interface GlobalVariableWriter<S : GlobalVariableWriter<S>> {
      * @return current writer instance
      * @see [io.holunda.camunda.bpm.data.adapter.WriteAdapter.set]
     </T> */
-    operator fun <T> set(variableFactory: VariableFactory<T>, value: T): S
+    operator fun <T> set(variableFactory: VariableFactory<T>, value: T?): S
 
     /**
      * Sets the (transient) value for the provided variable and returns the builder (fluently).
@@ -31,7 +31,7 @@ interface GlobalVariableWriter<S : GlobalVariableWriter<S>> {
      * @return current writer instance
      * @see [io.holunda.camunda.bpm.data.adapter.WriteAdapter.set]
     </T> */
-    operator fun <T> set(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): S
+    operator fun <T> set(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): S
 
     /**
      * Sets the global value for the provided variable and returns the builder (fluently).
@@ -42,7 +42,7 @@ interface GlobalVariableWriter<S : GlobalVariableWriter<S>> {
      * @return current writer instance
      * @see [io.holunda.camunda.bpm.data.adapter.WriteAdapter.setLocal]
     </T> */
-    fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>): S
+    fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>): S
 
     /**
      * Updates the global (transient) value for the provided variable and returns the builder (fluently).
@@ -54,7 +54,7 @@ interface GlobalVariableWriter<S : GlobalVariableWriter<S>> {
      * @return current writer instance
      * @see [io.holunda.camunda.bpm.data.adapter.WriteAdapter.setLocal]
     </T> */
-    fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>, isTransient: Boolean): S
+    fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>, isTransient: Boolean): S
 
     /**
      * Removes the value for the provided variable and returns the builder (fluently).

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/LocalVariableWriter.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/LocalVariableWriter.kt
@@ -19,7 +19,7 @@ interface LocalVariableWriter<S : LocalVariableWriter<S>> {
    * @return current writer instance
    * @see [io.holunda.camunda.bpm.data.adapter.WriteAdapter.setLocal]
   </T> */
-  fun <T> setLocal(variableFactory: VariableFactory<T>, value: T): S
+  fun <T> setLocal(variableFactory: VariableFactory<T>, value: T?): S
 
   /**
    * Sets the local (transient) value for the provided variable and returns the builder (fluently).
@@ -31,7 +31,7 @@ interface LocalVariableWriter<S : LocalVariableWriter<S>> {
    * @return current writer instance
    * @see [io.holunda.camunda.bpm.data.adapter.WriteAdapter.setLocal]
   </T> */
-  fun <T> setLocal(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): S
+  fun <T> setLocal(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): S
 
   /**
    * Sets the local value for the provided variable and returns the builder (fluently).
@@ -42,7 +42,7 @@ interface LocalVariableWriter<S : LocalVariableWriter<S>> {
    * @return current writer instance
    * @see [io.holunda.camunda.bpm.data.adapter.WriteAdapter.setLocal]
   </T> */
-  fun <T> updateLocal(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>): S
+  fun <T> updateLocal(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>): S
 
   /**
    * Updates the local (transient) value for the provided variable and returns the builder (fluently).
@@ -54,7 +54,7 @@ interface LocalVariableWriter<S : LocalVariableWriter<S>> {
    * @return current writer instance
    * @see [io.holunda.camunda.bpm.data.adapter.WriteAdapter.setLocal]
   </T> */
-  fun <T> updateLocal(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>, isTransient: Boolean): S
+  fun <T> updateLocal(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>, isTransient: Boolean): S
 
   /**
    * Removes the local value for the provided variable and returns the builder (fluently).

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/RuntimeServiceVariableWriter.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/RuntimeServiceVariableWriter.kt
@@ -19,22 +19,22 @@ class RuntimeServiceVariableWriter(private val runtimeService: RuntimeService, p
     return runtimeService.getVariablesLocalTyped(executionId)
   }
 
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T): RuntimeServiceVariableWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?): RuntimeServiceVariableWriter {
     return this.set(variableFactory, value, false)
   }
 
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): RuntimeServiceVariableWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): RuntimeServiceVariableWriter {
     variableFactory.on(runtimeService, executionId)[value] = isTransient
     return this
   }
 
-  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T): RuntimeServiceVariableWriter {
+  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T?): RuntimeServiceVariableWriter {
     return this.setLocal(variableFactory, value, false)
   }
 
   override fun <T> setLocal(
     variableFactory: VariableFactory<T>,
-    value: T,
+    value: T?,
     isTransient: Boolean
   ): RuntimeServiceVariableWriter {
     variableFactory.on(runtimeService, executionId).setLocal(value, isTransient)
@@ -51,14 +51,14 @@ class RuntimeServiceVariableWriter(private val runtimeService: RuntimeService, p
     return this
   }
 
-  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>): RuntimeServiceVariableWriter {
+  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>): RuntimeServiceVariableWriter {
     variableFactory.on(runtimeService, executionId).update(valueProcessor)
     return this
   }
 
   override fun <T> update(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>,
+    valueProcessor: Function<T?, T?>,
     isTransient: Boolean
   ): RuntimeServiceVariableWriter {
     variableFactory.on(runtimeService, executionId).update(valueProcessor, isTransient)
@@ -67,7 +67,7 @@ class RuntimeServiceVariableWriter(private val runtimeService: RuntimeService, p
 
   override fun <T> updateLocal(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>
+    valueProcessor: Function<T?, T?>
   ): RuntimeServiceVariableWriter {
     variableFactory.on(runtimeService, executionId).updateLocal(valueProcessor)
     return this
@@ -75,7 +75,7 @@ class RuntimeServiceVariableWriter(private val runtimeService: RuntimeService, p
 
   override fun <T> updateLocal(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>,
+    valueProcessor: Function<T?, T?>,
     isTransient: Boolean
   ): RuntimeServiceVariableWriter {
     variableFactory.on(runtimeService, executionId).updateLocal(valueProcessor, isTransient)

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/TaskServiceVariableWriter.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/TaskServiceVariableWriter.kt
@@ -19,20 +19,20 @@ class TaskServiceVariableWriter(private val taskService: TaskService, private va
     return taskService.getVariablesLocalTyped(taskId)
   }
 
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T): TaskServiceVariableWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?): TaskServiceVariableWriter {
     return this.set(variableFactory, value, false)
   }
 
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): TaskServiceVariableWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): TaskServiceVariableWriter {
     variableFactory.on(taskService, taskId)[value] = isTransient
     return this
   }
 
-  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T): TaskServiceVariableWriter {
+  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T?): TaskServiceVariableWriter {
     return this.setLocal(variableFactory, value, false)
   }
 
-  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): TaskServiceVariableWriter {
+  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): TaskServiceVariableWriter {
     variableFactory.on(taskService, taskId).setLocal(value, isTransient)
     return this
   }
@@ -47,14 +47,14 @@ class TaskServiceVariableWriter(private val taskService: TaskService, private va
     return this
   }
 
-  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>): TaskServiceVariableWriter {
+  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>): TaskServiceVariableWriter {
     variableFactory.on(taskService, taskId).update(valueProcessor)
     return this
   }
 
   override fun <T> update(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>,
+    valueProcessor: Function<T?, T?>,
     isTransient: Boolean
   ): TaskServiceVariableWriter {
     variableFactory.on(taskService, taskId).update(valueProcessor, isTransient)
@@ -63,7 +63,7 @@ class TaskServiceVariableWriter(private val taskService: TaskService, private va
 
   override fun <T> updateLocal(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>
+    valueProcessor: Function<T?, T?>
   ): TaskServiceVariableWriter {
     variableFactory.on(taskService, taskId).updateLocal(valueProcessor)
     return this
@@ -71,7 +71,7 @@ class TaskServiceVariableWriter(private val taskService: TaskService, private va
 
   override fun <T> updateLocal(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>,
+    valueProcessor: Function<T?, T?>,
     isTransient: Boolean
   ): TaskServiceVariableWriter {
     variableFactory.on(taskService, taskId).updateLocal(valueProcessor, isTransient)

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/VariableMapWriter.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/VariableMapWriter.kt
@@ -9,11 +9,11 @@ import java.util.function.Function
  * @param variables variables to work on.
  */
 class VariableMapWriter(private val variables: VariableMap) : GlobalVariableWriter<VariableMapWriter> {
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T): VariableMapWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?): VariableMapWriter {
     return this.set(variableFactory, value, false)
   }
 
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): VariableMapWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): VariableMapWriter {
     variableFactory.on(variables)[value] = isTransient
     return this
   }
@@ -23,14 +23,14 @@ class VariableMapWriter(private val variables: VariableMap) : GlobalVariableWrit
     return this
   }
 
-  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>): VariableMapWriter {
+  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>): VariableMapWriter {
     variableFactory.on(variables).update(valueProcessor)
     return this
   }
 
   override fun <T> update(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>,
+    valueProcessor: Function<T?, T?>,
     isTransient: Boolean
   ): VariableMapWriter {
     variableFactory.on(variables).update(valueProcessor, isTransient)

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/VariableScopeWriter.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/writer/VariableScopeWriter.kt
@@ -10,46 +10,46 @@ import java.util.function.Function
  * @param scope variables to work on.
  */
 class VariableScopeWriter(private val scope: VariableScope) : VariableWriter<VariableScopeWriter> {
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T): VariableScopeWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?): VariableScopeWriter {
     return this.set(variableFactory, value, false)
   }
 
-  override fun <T> set(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): VariableScopeWriter {
+  override fun <T> set(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): VariableScopeWriter {
     variableFactory.on(scope)[value] = isTransient
     return this
   }
 
-  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T): VariableScopeWriter {
+  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T?): VariableScopeWriter {
     return this.setLocal(variableFactory, value, false)
   }
 
-  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T, isTransient: Boolean): VariableScopeWriter {
+  override fun <T> setLocal(variableFactory: VariableFactory<T>, value: T?, isTransient: Boolean): VariableScopeWriter {
     variableFactory.on(scope).setLocal(value, isTransient)
     return this
   }
 
-  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>): VariableScopeWriter {
+  override fun <T> update(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>): VariableScopeWriter {
     variableFactory.on(scope).update(valueProcessor)
     return this
   }
 
   override fun <T> update(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>,
+    valueProcessor: Function<T?, T?>,
     isTransient: Boolean
   ): VariableScopeWriter {
     variableFactory.on(scope).update(valueProcessor, isTransient)
     return this
   }
 
-  override fun <T> updateLocal(variableFactory: VariableFactory<T>, valueProcessor: Function<T, T>): VariableScopeWriter {
+  override fun <T> updateLocal(variableFactory: VariableFactory<T>, valueProcessor: Function<T?, T?>): VariableScopeWriter {
     variableFactory.on(scope).updateLocal(valueProcessor)
     return this
   }
 
   override fun <T> updateLocal(
     variableFactory: VariableFactory<T>,
-    valueProcessor: Function<T, T>,
+    valueProcessor: Function<T?, T?>,
     isTransient: Boolean
   ): VariableScopeWriter {
     variableFactory.on(scope).updateLocal(valueProcessor, isTransient)

--- a/extension/core/src/test/kotlin/io/holunda/camunda/bpm/data/FluentApiTest.kt
+++ b/extension/core/src/test/kotlin/io/holunda/camunda/bpm/data/FluentApiTest.kt
@@ -44,7 +44,7 @@ class FluentApiTest {
     fake.set(MY_VAR, "new val")
     assertThat(fake[MY_VAR]).isEqualTo("new val")
 
-    fake.update(MY_VAR, { v -> v.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }, false)
+    fake.update(MY_VAR, { v -> v?.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }, false)
     assertThat(fake[MY_VAR]).isEqualTo("New val")
 
     fake.remove(MY_VAR)
@@ -68,13 +68,13 @@ class FluentApiTest {
     fake.set(MY_VAR, "new val")
     assertThat(fake[MY_VAR]).isEqualTo("new val")
 
-    fake.update(MY_VAR, { v -> v.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }, false)
+    fake.update(MY_VAR, { v -> v?.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }, false)
     assertThat(fake[MY_VAR]).isEqualTo("New val")
 
     fake.setLocal(MY_VAR, "another new local val")
     assertThat(fake.getLocal(MY_VAR)).isEqualTo("another new local val")
 
-    fake.updateLocal(MY_VAR, { v -> v.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }, false)
+    fake.updateLocal(MY_VAR, { v -> v?.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }, false)
     assertThat(fake[MY_VAR]).isEqualTo("Another new local val")
 
     fake.removeLocal(MY_VAR)
@@ -83,7 +83,7 @@ class FluentApiTest {
     localVars.set(MY_VAR, "new val")
     assertThat(localVars[MY_VAR]).isEqualTo("new val")
 
-    localVars.update(MY_VAR, { v -> v.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }, false)
+    localVars.update(MY_VAR, { v -> v?.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }, false)
     assertThat(localVars[MY_VAR]).isEqualTo("New val")
 
     localVars.remove(MY_VAR)


### PR DESCRIPTION
Fix #394 

I believe it is not the bound which needs to be changed, since Java `String` means StringOrNull on set.