### PR TITLE
Fix nullable kotlin types

### DIFF
--- a/example/example-kotlin/src/main/kotlin/process/OrderApproval.kt
+++ b/example/example-kotlin/src/main/kotlin/process/OrderApproval.kt
@@ -42,7 +42,7 @@ class OrderApproval {
   }
 
   object Variables {
-    val ORDER_ID = stringVariable("orderId")
+    val ORDER_ID = stringVariable("orderId").nonNull
     val ORDER: VariableFactory<Order> = customVariable("order")
     val ORDER_APPROVED = booleanVariable("orderApproved")
     val ORDER_POSITION: VariableFactory<OrderPosition> = customVariable("orderPosition")

--- a/example/example-kotlin/src/main/kotlin/process/OrderApproval.kt
+++ b/example/example-kotlin/src/main/kotlin/process/OrderApproval.kt
@@ -43,8 +43,8 @@ class OrderApproval {
 
   object Variables {
     val ORDER_ID = stringVariable("orderId").nonNull
+    val ORDER_APPROVED = booleanVariable("orderApproved").nonNull
     val ORDER: VariableFactory<Order> = customVariable("order")
-    val ORDER_APPROVED = booleanVariable("orderApproved")
     val ORDER_POSITION: VariableFactory<OrderPosition> = customVariable("orderPosition")
     val ORDER_TOTAL: VariableFactory<BigDecimal> = customVariable("orderTotal")
   }

--- a/example/example-no-engine/pom.xml
+++ b/example/example-no-engine/pom.xml
@@ -20,13 +20,6 @@
     <dependency>
       <groupId>io.holunda.data</groupId>
       <artifactId>camunda-bpm-data</artifactId>
-      <exclusions>
-        <!-- Camunda Engine is NOT on the classpath -->
-        <exclusion>
-          <groupId>org.camunda.bpm</groupId>
-          <artifactId>camunda-engine</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/example/itest/src/test/kotlin/itest/CamundaBpmDataITestBase.kt
+++ b/example/itest/src/test/kotlin/itest/CamundaBpmDataITestBase.kt
@@ -78,12 +78,12 @@ abstract class CamundaBpmDataITestBase : SpringScenarioTest<ActionStage, ActionS
   companion object {
 
     val STRING_VAR: VariableFactory<String> = stringVariable("String Variable").nonNull
-    val DATE_VAR: VariableFactory<Date> = dateVariable("Date Variable")
-    val SHORT_VAR: VariableFactory<Short> = shortVariable("Short Variable")
-    val INT_VAR: VariableFactory<Int> = intVariable("Int Variable")
-    val LONG_VAR: VariableFactory<Long> = longVariable("Long Variable")
-    val DOUBLE_VAR: VariableFactory<Double> = doubleVariable("Double Variable")
-    val BOOLEAN_VAR: VariableFactory<Boolean> = booleanVariable("Boolean Variable")
+    val DATE_VAR: VariableFactory<Date> = dateVariable("Date Variable").nonNull
+    val SHORT_VAR: VariableFactory<Short> = shortVariable("Short Variable").nonNull
+    val INT_VAR: VariableFactory<Int> = intVariable("Int Variable").nonNull
+    val LONG_VAR: VariableFactory<Long> = longVariable("Long Variable").nonNull
+    val DOUBLE_VAR: VariableFactory<Double> = doubleVariable("Double Variable").nonNull
+    val BOOLEAN_VAR: VariableFactory<Boolean> = booleanVariable("Boolean Variable").nonNull
     val COMPLEX_VAR: VariableFactory<ComplexDataStructure> = customVariable("Complex Variable")
     val LIST_STRING_VAR: VariableFactory<List<String>> = listVariable("List Of String Variable")
     val SET_STRING_VAR: VariableFactory<Set<String>> = setVariable("Set Of String Variable")

--- a/example/itest/src/test/kotlin/itest/CamundaBpmDataITestBase.kt
+++ b/example/itest/src/test/kotlin/itest/CamundaBpmDataITestBase.kt
@@ -77,7 +77,7 @@ abstract class CamundaBpmDataITestBase : SpringScenarioTest<ActionStage, ActionS
 
   companion object {
 
-    val STRING_VAR: VariableFactory<String> = stringVariable("String Variable")
+    val STRING_VAR: VariableFactory<String> = stringVariable("String Variable").nonNull
     val DATE_VAR: VariableFactory<Date> = dateVariable("Date Variable")
     val SHORT_VAR: VariableFactory<Short> = shortVariable("Short Variable")
     val INT_VAR: VariableFactory<Int> = intVariable("Int Variable")

--- a/extension/core/pom.xml
+++ b/extension/core/pom.xml
@@ -20,14 +20,6 @@
   </properties>
 
   <dependencies>
-
-    <!--
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>camunda-bpm-data-c7</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    -->
     <!-- Kotlin -->
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/CamundaBpmDataKotlin.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/CamundaBpmDataKotlin.kt
@@ -15,7 +15,7 @@ object CamundaBpmDataKotlin {
    *
    * @return variable factory for string.
    */
-  fun stringVariable(variableName: String): VariableFactory<String> = BasicVariableFactory(variableName, String::class.java)
+  fun stringVariable(variableName: String): VariableFactory<String?> = BasicVariableFactory.forType<String?>(variableName)
 
   /**
    * Creates a date variable factory.

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/CamundaBpmDataKotlin.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/CamundaBpmDataKotlin.kt
@@ -24,7 +24,7 @@ object CamundaBpmDataKotlin {
    *
    * @return variable factory for date.
    */
-  fun dateVariable(variableName: String): VariableFactory<Date> = BasicVariableFactory(variableName, Date::class.java)
+  fun dateVariable(variableName: String): VariableFactory<Date?> = BasicVariableFactory.forType(variableName)
 
   /**
    * Creates an integer variable factory.
@@ -33,7 +33,7 @@ object CamundaBpmDataKotlin {
    *
    * @return variable factory for integer.
    */
-  fun intVariable(variableName: String): VariableFactory<Int> = BasicVariableFactory(variableName, Int::class.java)
+  fun intVariable(variableName: String): VariableFactory<Int?> = BasicVariableFactory.forType(variableName)
 
   /**
    * Creates a long variable factory.
@@ -42,7 +42,7 @@ object CamundaBpmDataKotlin {
    *
    * @return variable factory for long.
    */
-  fun longVariable(variableName: String): VariableFactory<Long> = BasicVariableFactory(variableName, Long::class.java)
+  fun longVariable(variableName: String): VariableFactory<Long?> = BasicVariableFactory.forType(variableName)
 
   /**
    * Creates a short variable factory.
@@ -51,7 +51,7 @@ object CamundaBpmDataKotlin {
    *
    * @return variable factory for short.
    */
-  fun shortVariable(variableName: String): VariableFactory<Short> = BasicVariableFactory(variableName, Short::class.java)
+  fun shortVariable(variableName: String): VariableFactory<Short?> = BasicVariableFactory.forType(variableName)
 
   /**
    * Creates a double variable factory.
@@ -60,7 +60,7 @@ object CamundaBpmDataKotlin {
    *
    * @return variable factory for double.
    */
-  fun doubleVariable(variableName: String): VariableFactory<Double> = BasicVariableFactory(variableName, Double::class.java)
+  fun doubleVariable(variableName: String): VariableFactory<Double?> = BasicVariableFactory.forType(variableName)
 
   /**
    * Creates a boolean variable factory.
@@ -69,7 +69,7 @@ object CamundaBpmDataKotlin {
    *
    * @return variable factory for boolean.
    */
-  fun booleanVariable(variableName: String): VariableFactory<Boolean> = BasicVariableFactory(variableName, Boolean::class.java)
+  fun booleanVariable(variableName: String): VariableFactory<Boolean?> = BasicVariableFactory.forType(variableName)
 
   /**
    * Creates an uuid variable factory.
@@ -77,7 +77,7 @@ object CamundaBpmDataKotlin {
    * @param variableName name of the variable.
    * @return variable factory for uuid.
    */
-  fun uuidVariable(variableName: String): VariableFactory<UUID> = BasicVariableFactory(variableName, UUID::class.java)
+  fun uuidVariable(variableName: String): VariableFactory<UUID?> = BasicVariableFactory.forType(variableName)
 
   /**
    * Reified version of the basic variable factory.
@@ -85,7 +85,7 @@ object CamundaBpmDataKotlin {
    * @param T The type of the variable.
    * @return instance of [VariableFactory]
    */
-  inline fun <reified T : Any> customVariable(name: String): VariableFactory<T> = BasicVariableFactory(name, T::class.java)
+  inline fun <reified T : Any?> customVariable(name: String): VariableFactory<T> = BasicVariableFactory.forType(name)
 
   /**
    * Reified version of list variable factory.
@@ -93,7 +93,7 @@ object CamundaBpmDataKotlin {
    * @param T The type of the variable.
    * @return instance of [VariableFactory]
    */
-  inline fun <reified T : Any?> listVariable(name: String): VariableFactory<List<T>> = ListVariableFactory(name, T::class.java)
+  inline fun <reified T : Any?> listVariable(name: String): VariableFactory<List<T>> = ListVariableFactory.forType(name)
 
   /**
    * Reified version of list variable factory.
@@ -101,7 +101,7 @@ object CamundaBpmDataKotlin {
    * @param T The type of the variable.
    * @return instance of [VariableFactory]
    */
-  inline fun <reified T : Any> listVariableNotNull(name: String): VariableFactory<List<T>> = ListVariableFactory(name, T::class.java)
+  inline fun <reified T : Any> listVariableNotNull(name: String): VariableFactory<List<T>> = ListVariableFactory.forType(name)
 
   /**
    * Reified version of set variable factory.
@@ -110,7 +110,7 @@ object CamundaBpmDataKotlin {
    * @param wrap a boolean flag controlling if the serializer should wrap a list into a wrapper object. Set this flag to true, if you use complex types as T.
    * @return instance of [VariableFactory]
    */
-  inline fun <reified T : Any?> setVariable(name: String): VariableFactory<Set<T>> = SetVariableFactory(name, T::class.java)
+  inline fun <reified T : Any?> setVariable(name: String): VariableFactory<Set<T>> = SetVariableFactory.forType(name)
 
   /**
    * Reified version of set variable factory.
@@ -119,7 +119,7 @@ object CamundaBpmDataKotlin {
    * @param wrap a boolean flag controlling if the serializer should wrap a list into a wrapper object. Set this flag to true, if you use complex types as T.
    * @return instance of [VariableFactory]
    */
-  inline fun <reified T : Any> setVariableNotNull(name: String): VariableFactory<Set<T>> = SetVariableFactory(name, T::class.java)
+  inline fun <reified T : Any> setVariableNotNull(name: String): VariableFactory<Set<T>> = SetVariableFactory.forType(name)
 
   /**
    * Reified version of map variable factory.
@@ -128,7 +128,7 @@ object CamundaBpmDataKotlin {
    * @param V The type of the variable value.
    * @return instance of [VariableFactory]
    */
-  inline fun <reified K : Any, reified V : Any?> mapVariable(name: String): VariableFactory<Map<K, V>> = MapVariableFactory(name, K::class.java, V::class.java)
+  inline fun <reified K : Any, reified V : Any?> mapVariable(name: String): VariableFactory<Map<K, V>> = MapVariableFactory.forType(name)
 
   /**
    * Reified version of map variable factory.
@@ -137,6 +137,6 @@ object CamundaBpmDataKotlin {
    * @param V The type of the variable value.
    * @return instance of [VariableFactory]
    */
-  inline fun <reified K : Any, reified V : Any> mapVariableNotNullable(name: String): VariableFactory<Map<K, V>> = MapVariableFactory(name, K::class.java, V::class.java)
+  inline fun <reified K : Any, reified V : Any> mapVariableNotNullable(name: String): VariableFactory<Map<K, V>> = MapVariableFactory.forType(name)
 
 }

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadAdapterLockedExternalTask.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadAdapterLockedExternalTask.kt
@@ -9,7 +9,7 @@ import java.util.*
  *
  * @param [T] type of value.
  */
-class ReadAdapterLockedExternalTask<T : Any>(
+class ReadAdapterLockedExternalTask<T : Any?>(
   private val lockedExternalTask: LockedExternalTask,
   variableName: String,
   clazz: Class<T>
@@ -23,7 +23,7 @@ class ReadAdapterLockedExternalTask<T : Any>(
       getOrNull(
         value
       )
-    )
+    ) as Optional<T>
   }
 
   override fun set(value: T, isTransient: Boolean) {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadAdapterLockedExternalTask.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadAdapterLockedExternalTask.kt
@@ -19,6 +19,7 @@ class ReadAdapterLockedExternalTask<T : Any?>(
       .orElse(Variables.createVariables())[variableName]
 
   override fun getOptional(): Optional<T> {
+    @Suppress("UNCHECKED_CAST")
     return Optional.ofNullable(
       getOrNull(
         value

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterCaseService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterCaseService.kt
@@ -12,7 +12,7 @@ import java.util.*
  * @param variableName    name of the variable.
  * @param clazz           class of the variable.
  */
-class ReadWriteAdapterCaseService<T : Any>(
+class ReadWriteAdapterCaseService<T : Any?>(
   private val caseService: CaseService,
   private val caseExecutionId: String,
   variableName: String,
@@ -20,7 +20,7 @@ class ReadWriteAdapterCaseService<T : Any>(
 ) : AbstractBasicReadWriteAdapter<T>(variableName, clazz) {
 
   override fun getOptional(): Optional<T> {
-    return Optional.ofNullable(getOrNull(caseService.getVariable(caseExecutionId, variableName)))
+    return Optional.ofNullable(getOrNull(caseService.getVariable(caseExecutionId, variableName))) as Optional<T>
   }
 
   override fun set(value: T, isTransient: Boolean) {
@@ -28,7 +28,7 @@ class ReadWriteAdapterCaseService<T : Any>(
   }
 
   override fun getLocalOptional(): Optional<T> {
-    return Optional.ofNullable(getOrNull(caseService.getVariableLocal(caseExecutionId, variableName)))
+    return Optional.ofNullable(getOrNull(caseService.getVariableLocal(caseExecutionId, variableName))) as Optional<T>
   }
 
   override fun setLocal(value: T, isTransient: Boolean) {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterCaseService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterCaseService.kt
@@ -20,6 +20,7 @@ class ReadWriteAdapterCaseService<T : Any?>(
 ) : AbstractBasicReadWriteAdapter<T>(variableName, clazz) {
 
   override fun getOptional(): Optional<T> {
+    @Suppress("UNCHECKED_CAST")
     return Optional.ofNullable(getOrNull(caseService.getVariable(caseExecutionId, variableName))) as Optional<T>
   }
 
@@ -28,6 +29,7 @@ class ReadWriteAdapterCaseService<T : Any?>(
   }
 
   override fun getLocalOptional(): Optional<T> {
+    @Suppress("UNCHECKED_CAST")
     return Optional.ofNullable(getOrNull(caseService.getVariableLocal(caseExecutionId, variableName))) as Optional<T>
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterRuntimeService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterRuntimeService.kt
@@ -19,6 +19,7 @@ class ReadWriteAdapterRuntimeService<T : Any?>(
   clazz: Class<T>
 ) : AbstractBasicReadWriteAdapter<T>(variableName, clazz) {
   override fun getOptional(): Optional<T> {
+    @Suppress("UNCHECKED_CAST")
     return Optional.ofNullable(getOrNull(runtimeService.getVariable(executionId, variableName))) as Optional<T>
   }
 
@@ -27,6 +28,7 @@ class ReadWriteAdapterRuntimeService<T : Any?>(
   }
 
   override fun getLocalOptional(): Optional<T> {
+    @Suppress("UNCHECKED_CAST")
     return Optional.ofNullable(getOrNull(runtimeService.getVariableLocal(executionId, variableName))) as Optional<T>
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterRuntimeService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterRuntimeService.kt
@@ -12,14 +12,14 @@ import java.util.*
  * @param variableName   name of the variable.
  * @param clazz          class of the variable.
  */
-class ReadWriteAdapterRuntimeService<T : Any>(
+class ReadWriteAdapterRuntimeService<T : Any?>(
   private val runtimeService: RuntimeService,
   private val executionId: String,
   variableName: String,
   clazz: Class<T>
 ) : AbstractBasicReadWriteAdapter<T>(variableName, clazz) {
   override fun getOptional(): Optional<T> {
-    return Optional.ofNullable(getOrNull(runtimeService.getVariable(executionId, variableName)))
+    return Optional.ofNullable(getOrNull(runtimeService.getVariable(executionId, variableName))) as Optional<T>
   }
 
   override fun set(value: T, isTransient: Boolean) {
@@ -27,7 +27,7 @@ class ReadWriteAdapterRuntimeService<T : Any>(
   }
 
   override fun getLocalOptional(): Optional<T> {
-    return Optional.ofNullable(getOrNull(runtimeService.getVariableLocal(executionId, variableName)))
+    return Optional.ofNullable(getOrNull(runtimeService.getVariableLocal(executionId, variableName))) as Optional<T>
   }
 
   override fun setLocal(value: T, isTransient: Boolean) {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterTaskService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterTaskService.kt
@@ -19,6 +19,7 @@ class ReadWriteAdapterTaskService<T: Any?>(
     clazz: Class<T>
 ) : AbstractBasicReadWriteAdapter<T>(variableName, clazz) {
     override fun getOptional(): Optional<T> {
+        @Suppress("UNCHECKED_CAST")
         return Optional.ofNullable(getOrNull(taskService.getVariable(taskId, variableName))) as Optional<T>
     }
 
@@ -27,6 +28,7 @@ class ReadWriteAdapterTaskService<T: Any?>(
     }
 
     override fun getLocalOptional(): Optional<T> {
+        @Suppress("UNCHECKED_CAST")
         return Optional.ofNullable(getOrNull(taskService.getVariableLocal(taskId, variableName))) as Optional<T>
     }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterTaskService.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterTaskService.kt
@@ -12,14 +12,14 @@ import java.util.*
  * @param variableName name of the variable.
  * @param clazz        class of the variable.
 </T> */
-class ReadWriteAdapterTaskService<T: Any>(
+class ReadWriteAdapterTaskService<T: Any?>(
     private val taskService: TaskService,
     private val taskId: String,
     variableName: String,
     clazz: Class<T>
 ) : AbstractBasicReadWriteAdapter<T>(variableName, clazz) {
     override fun getOptional(): Optional<T> {
-        return Optional.ofNullable(getOrNull(taskService.getVariable(taskId, variableName)))
+        return Optional.ofNullable(getOrNull(taskService.getVariable(taskId, variableName))) as Optional<T>
     }
 
     override fun set(value: T, isTransient: Boolean) {
@@ -27,7 +27,7 @@ class ReadWriteAdapterTaskService<T: Any>(
     }
 
     override fun getLocalOptional(): Optional<T> {
-        return Optional.ofNullable(getOrNull(taskService.getVariableLocal(taskId, variableName)))
+        return Optional.ofNullable(getOrNull(taskService.getVariableLocal(taskId, variableName))) as Optional<T>
     }
 
     override fun setLocal(value: T, isTransient: Boolean) {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableMap.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableMap.kt
@@ -11,11 +11,11 @@ import java.util.*
  * @param variableName variable to access.
  * @param clazz        class of variable value.
  */
-class ReadWriteAdapterVariableMap<T : Any>(private val variableMap: VariableMap, variableName: String, clazz: Class<T>) :
+class ReadWriteAdapterVariableMap<T : Any?>(private val variableMap: VariableMap, variableName: String, clazz: Class<T>) :
   AbstractBasicReadWriteAdapter<T>(variableName, clazz) {
 
   override fun getOptional(): Optional<T> {
-    return Optional.ofNullable(getOrNull(variableMap[variableName]))
+    return Optional.ofNullable(getOrNull(variableMap[variableName])) as Optional<T>
   }
 
   override fun set(value: T, isTransient: Boolean) {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableMap.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableMap.kt
@@ -15,6 +15,7 @@ class ReadWriteAdapterVariableMap<T : Any?>(private val variableMap: VariableMap
   AbstractBasicReadWriteAdapter<T>(variableName, clazz) {
 
   override fun getOptional(): Optional<T> {
+    @Suppress("UNCHECKED_CAST")
     return Optional.ofNullable(getOrNull(variableMap[variableName])) as Optional<T>
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableScope.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableScope.kt
@@ -21,6 +21,7 @@ class ReadWriteAdapterVariableScope<T: Any?>(
   }
 
   override fun getLocalOptional(): Optional<T> {
+    @Suppress("UNCHECKED_CAST")
     return Optional.ofNullable(getOrNull(variableScope.getVariableLocal(variableName))) as Optional<T>
   }
 
@@ -29,6 +30,7 @@ class ReadWriteAdapterVariableScope<T: Any?>(
   }
 
   override fun getOptional(): Optional<T> {
+    @Suppress("UNCHECKED_CAST")
     return Optional.ofNullable(getOrNull(variableScope.getVariable(variableName))) as Optional<T>
   }
 

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableScope.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/adapter/basic/ReadWriteAdapterVariableScope.kt
@@ -11,7 +11,7 @@ import java.util.*
  * @param variableName  variable to access.
  * @param clazz         class of variable value.
  */
-class ReadWriteAdapterVariableScope<T: Any>(
+class ReadWriteAdapterVariableScope<T: Any?>(
   private val variableScope: VariableScope,
   variableName: String,
   clazz: Class<T>
@@ -21,7 +21,7 @@ class ReadWriteAdapterVariableScope<T: Any>(
   }
 
   override fun getLocalOptional(): Optional<T> {
-    return Optional.ofNullable(getOrNull(variableScope.getVariableLocal(variableName)))
+    return Optional.ofNullable(getOrNull(variableScope.getVariableLocal(variableName))) as Optional<T>
   }
 
   override fun setLocal(value: T, isTransient: Boolean) {
@@ -29,7 +29,7 @@ class ReadWriteAdapterVariableScope<T: Any>(
   }
 
   override fun getOptional(): Optional<T> {
-    return Optional.ofNullable(getOrNull(variableScope.getVariable(variableName)))
+    return Optional.ofNullable(getOrNull(variableScope.getVariable(variableName))) as Optional<T>
   }
 
   override fun remove() {

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/BasicVariableFactory.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/BasicVariableFactory.kt
@@ -18,10 +18,14 @@ import java.util.*
  * @param name  name of the variable.
  * @param variableClass class of the type.
  */
-class BasicVariableFactory<T : Any>(
+class BasicVariableFactory<T : Any?>(
   override val name: String,
   val variableClass: Class<T>
 ) : VariableFactory<T> {
+
+  companion object {
+    inline fun <reified T> forType(name: String) = BasicVariableFactory(name, T::class.java)
+  }
 
   override fun on(variableScope: VariableScope): WriteAdapter<T> {
     return ReadWriteAdapterVariableScope(variableScope, name, variableClass)
@@ -156,7 +160,7 @@ class BasicVariableFactory<T : Any>(
    * @param basicVariableFactory variable factory to use.
    * @param runtimeService       task service to build adapter with.
    */
-  class BasicRuntimeServiceAdapterBuilder<T: Any>(
+  class BasicRuntimeServiceAdapterBuilder<T: Any?>(
     private val basicVariableFactory: BasicVariableFactory<T>,
     private val runtimeService: RuntimeService
   ) {
@@ -197,7 +201,7 @@ class BasicVariableFactory<T : Any>(
    * @param basicVariableFactory variable factory to use.
    * @param taskService          task service to build adapter with.
    */
-  class BasicTaskServiceAdapterBuilder<T: Any>(private val basicVariableFactory: BasicVariableFactory<T>, private val taskService: TaskService) {
+  class BasicTaskServiceAdapterBuilder<T: Any?>(private val basicVariableFactory: BasicVariableFactory<T>, private val taskService: TaskService) {
     private fun readWriteAdapter(taskId: String): ReadWriteAdapterTaskService<T> {
       return ReadWriteAdapterTaskService(
         taskService,
@@ -235,7 +239,7 @@ class BasicVariableFactory<T : Any>(
    * @param basicVariableFactory variable factory to use.
    * @param caseService          task service to build adapter with.
    */
-  class BasicCaseServiceAdapterBuilder<T: Any>(private val basicVariableFactory: BasicVariableFactory<T>, private val caseService: CaseService) {
+  class BasicCaseServiceAdapterBuilder<T: Any?>(private val basicVariableFactory: BasicVariableFactory<T>, private val caseService: CaseService) {
     private fun readWriteAdapter(caseExecutionId: String): ReadWriteAdapterCaseService<T> {
       return ReadWriteAdapterCaseService(
         caseService,

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/ListVariableFactory.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/ListVariableFactory.kt
@@ -18,107 +18,111 @@ import java.util.*
  */
 class ListVariableFactory<T>(override val name: String, val memberClass: Class<T>) : VariableFactory<List<T>> {
 
-    override fun on(variableScope: VariableScope): WriteAdapter<List<T>> {
-        return ListReadWriteAdapterVariableScope(
-          variableScope,
-          name,
-          memberClass
-        )
-    }
+  companion object {
+    inline fun <reified T> forType(name: String) = ListVariableFactory(name, T::class.java)
+  }
 
-    override fun from(variableScope: VariableScope): ReadAdapter<List<T>> {
-        return ListReadWriteAdapterVariableScope(
-          variableScope,
-          name,
-          memberClass
-        )
-    }
+  override fun on(variableScope: VariableScope): WriteAdapter<List<T>> {
+    return ListReadWriteAdapterVariableScope(
+      variableScope,
+      name,
+      memberClass
+    )
+  }
 
-    override fun on(variableMap: VariableMap): WriteAdapter<List<T>> {
-        return ListReadWriteAdapterVariableMap(variableMap, name, memberClass)
-    }
+  override fun from(variableScope: VariableScope): ReadAdapter<List<T>> {
+    return ListReadWriteAdapterVariableScope(
+      variableScope,
+      name,
+      memberClass
+    )
+  }
 
-    override fun from(variableMap: VariableMap): ReadAdapter<List<T>> {
-        return ListReadWriteAdapterVariableMap(variableMap, name, memberClass)
-    }
+  override fun on(variableMap: VariableMap): WriteAdapter<List<T>> {
+    return ListReadWriteAdapterVariableMap(variableMap, name, memberClass)
+  }
 
-    override fun on(runtimeService: RuntimeService, executionId: String): WriteAdapter<List<T>> {
-        return ListReadWriteAdapterRuntimeService(
-          runtimeService,
-          executionId,
-          name,
-          memberClass
-        )
-    }
+  override fun from(variableMap: VariableMap): ReadAdapter<List<T>> {
+    return ListReadWriteAdapterVariableMap(variableMap, name, memberClass)
+  }
 
-    override fun from(runtimeService: RuntimeService, executionId: String): ReadAdapter<List<T>> {
-        return ListReadWriteAdapterRuntimeService(
-          runtimeService,
-          executionId,
-          name,
-          memberClass
-        )
-    }
+  override fun on(runtimeService: RuntimeService, executionId: String): WriteAdapter<List<T>> {
+    return ListReadWriteAdapterRuntimeService(
+      runtimeService,
+      executionId,
+      name,
+      memberClass
+    )
+  }
 
-    override fun on(taskService: TaskService, taskId: String): WriteAdapter<List<T>> {
-        return ListReadWriteAdapterTaskService(
-          taskService,
-          taskId,
-          name,
-          memberClass
-        )
-    }
+  override fun from(runtimeService: RuntimeService, executionId: String): ReadAdapter<List<T>> {
+    return ListReadWriteAdapterRuntimeService(
+      runtimeService,
+      executionId,
+      name,
+      memberClass
+    )
+  }
 
-    override fun from(taskService: TaskService, taskId: String): ReadAdapter<List<T>> {
-        return ListReadWriteAdapterTaskService(
-          taskService,
-          taskId,
-          name,
-          memberClass
-        )
-    }
+  override fun on(taskService: TaskService, taskId: String): WriteAdapter<List<T>> {
+    return ListReadWriteAdapterTaskService(
+      taskService,
+      taskId,
+      name,
+      memberClass
+    )
+  }
 
-    override fun on(caseService: CaseService, caseExecutionId: String): WriteAdapter<List<T>> {
-        return ListReadWriteAdapterCaseService(
-          caseService,
-          caseExecutionId,
-          name,
-          memberClass
-        )
-    }
+  override fun from(taskService: TaskService, taskId: String): ReadAdapter<List<T>> {
+    return ListReadWriteAdapterTaskService(
+      taskService,
+      taskId,
+      name,
+      memberClass
+    )
+  }
 
-    override fun from(caseService: CaseService, caseExecutionId: String): ReadAdapter<List<T>> {
-        return ListReadWriteAdapterCaseService(
-          caseService,
-          caseExecutionId,
-          name,
-          memberClass
-        )
-    }
+  override fun on(caseService: CaseService, caseExecutionId: String): WriteAdapter<List<T>> {
+    return ListReadWriteAdapterCaseService(
+      caseService,
+      caseExecutionId,
+      name,
+      memberClass
+    )
+  }
 
-    override fun from(lockedExternalTask: LockedExternalTask): ReadAdapter<List<T>> {
-        return ListReadAdapterLockedExternalTask(
-          lockedExternalTask,
-          name,
-          memberClass
-        )
-    }
+  override fun from(caseService: CaseService, caseExecutionId: String): ReadAdapter<List<T>> {
+    return ListReadWriteAdapterCaseService(
+      caseService,
+      caseExecutionId,
+      name,
+      memberClass
+    )
+  }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || javaClass != other.javaClass) return false
-        val that = other as ListVariableFactory<*>
-        return name == that.name && memberClass == that.memberClass
-    }
+  override fun from(lockedExternalTask: LockedExternalTask): ReadAdapter<List<T>> {
+    return ListReadAdapterLockedExternalTask(
+      lockedExternalTask,
+      name,
+      memberClass
+    )
+  }
 
-    override fun hashCode(): Int {
-        return Objects.hash(name, memberClass)
-    }
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || javaClass != other.javaClass) return false
+    val that = other as ListVariableFactory<*>
+    return name == that.name && memberClass == that.memberClass
+  }
 
-    override fun toString(): String {
-        return "ListVariableFactory{" +
-                "name='" + name + '\'' +
-                ", memberClazz=" + memberClass +
-                '}'
-    }
+  override fun hashCode(): Int {
+    return Objects.hash(name, memberClass)
+  }
+
+  override fun toString(): String {
+    return "ListVariableFactory{" +
+      "name='" + name + '\'' +
+      ", memberClazz=" + memberClass +
+      '}'
+  }
 }

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/MapVariableFactory.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/MapVariableFactory.kt
@@ -23,6 +23,10 @@ class MapVariableFactory<K, V>(
   val valueClass: Class<V>
 ) : VariableFactory<Map<K, V>> {
 
+  companion object {
+    inline fun <reified K, reified V> forType(name: String) = MapVariableFactory(name, K::class.java, V::class.java)
+  }
+
   override fun on(variableScope: VariableScope): WriteAdapter<Map<K, V>> {
     return MapReadWriteAdapterVariableScope(
       variableScope,

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/SetVariableFactory.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/SetVariableFactory.kt
@@ -18,6 +18,10 @@ import java.util.*
  */
 class SetVariableFactory<T>(override val name: String, val memberClass: Class<T>) : VariableFactory<Set<T>> {
 
+  companion object {
+    inline fun <reified T> forType(name: String) = SetVariableFactory(name, T::class.java)
+  }
+
   override fun on(variableScope: VariableScope): WriteAdapter<Set<T>> {
     return SetReadWriteAdapterVariableScope(variableScope, name, memberClass)
   }

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/VariableFactory.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/VariableFactory.kt
@@ -15,6 +15,9 @@ import org.camunda.bpm.engine.variable.VariableMap
  * @param [T] type of the factory.
  */
 interface VariableFactory<T> {
+
+  val nonNull: VariableFactory<T & Any> get()=this as VariableFactory<T & Any>
+
   /**
    * Creates a write adapter for variable scope.
    *

--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/VariableFactory.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/factory/VariableFactory.kt
@@ -16,7 +16,8 @@ import org.camunda.bpm.engine.variable.VariableMap
  */
 interface VariableFactory<T> {
 
-  val nonNull: VariableFactory<T & Any> get()=this as VariableFactory<T & Any>
+  @Suppress("UNCHECKED_CAST")
+  val nonNull: VariableFactory<T & Any> get() = this as VariableFactory<T & Any>
 
   /**
    * Creates a write adapter for variable scope.

--- a/extension/core/src/test/kotlin/io/holunda/camunda/bpm/data/FluentApiTest.kt
+++ b/extension/core/src/test/kotlin/io/holunda/camunda/bpm/data/FluentApiTest.kt
@@ -23,7 +23,7 @@ class FluentApiTest {
     const val NAME = "myString"
     const val VALUE = "some random value"
     const val LOCAL_VALUE = "other local value"
-    val MY_VAR = stringVariable(NAME)
+    val MY_VAR = stringVariable(NAME).nonNull
   }
 
   @Test

--- a/extension/core/src/test/kotlin/io/holunda/camunda/bpm/data/acl/ACLTest.kt
+++ b/extension/core/src/test/kotlin/io/holunda/camunda/bpm/data/acl/ACLTest.kt
@@ -103,9 +103,9 @@ class TransientVariableMappingListenerTest {
 
   companion object {
 
-    private val FOO = CamundaBpmDataKotlin.stringVariable("foo")
-    private val BAZ = CamundaBpmDataKotlin.longVariable("baz")
-    private val BAZ_INTERNAL = CamundaBpmDataKotlin.longVariable("baz__int")
+    private val FOO = CamundaBpmDataKotlin.stringVariable("foo").nonNull
+    private val BAZ = CamundaBpmDataKotlin.longVariable("baz").nonNull
+    private val BAZ_INTERNAL = CamundaBpmDataKotlin.longVariable("baz__int").nonNull
 
     private val ACL_LR = CamundaBpmDataMapper.identityReplace("transient", true)
 


### PR DESCRIPTION
Alternative fix for #394 changing the bound of the default declaration in Kotlin from `T` to `T?` and adding additional `nonNull` on the factory to enforce the Kotlin factory for `T`.