### PR TITLE
[#454] changed signature of getOrDefault in Variable Reader

### DIFF
--- a/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/reader/VariableReader.kt
+++ b/extension/core/src/main/kotlin/io/holunda/camunda/bpm/data/reader/VariableReader.kt
@@ -63,7 +63,7 @@ interface VariableReader {
      * @param defaultValue      the default value if the variable is not set
      * @return value or default
      */
-    fun <T> getOrDefault(variableFactory: VariableFactory<T>, defaultValue: T?): T? {
+    fun <T> getOrDefault(variableFactory: VariableFactory<T>, defaultValue: T): T {
         return getOptional(variableFactory).orElse(defaultValue)
     }
 


### PR DESCRIPTION
The signature now specifies the intent of providing a non-null value for the default and also returning a non-null value. closes #454